### PR TITLE
Feature/jruby fixes

### DIFF
--- a/bin/blinkr
+++ b/bin/blinkr
@@ -1,5 +1,3 @@
-#!/usr/bin/env ruby
-
 require 'blinkr'
 require 'optparse'
 

--- a/lib/blinkr/engine.rb
+++ b/lib/blinkr/engine.rb
@@ -51,8 +51,7 @@ module Blinkr
         url = response.request.base_url
         if response.success?
           puts "Loaded page #{url}" if @config.verbose
-          body = Nokogiri::HTML(response.body)
-          page = OpenStruct.new({:response => response, :body => body.freeze,
+          page = OpenStruct.new({:response => response.freeze,
                                  :errors => ErrorArray.new(@config),
                                  :resource_errors => resource_errors || [],
                                  :javascript_errors => javascript_errors || []})
@@ -68,7 +67,6 @@ module Blinkr
       puts "Loaded #{page_count} pages using #{browser.name}."
       puts 'Analyzing pages'
       analyze context, bulk_browser
-      context.pages.reject! { |_, page| page.errors.empty? }
 
       unless @config.export.nil?
         FileUtils.mkdir_p Pathname.new(@config.report).parent
@@ -128,7 +126,7 @@ module Blinkr
 
     def execute(method, *args)
       result = []
-      Parallel.each(@extensions, :in_threads => Parallel.processor_count * 3) do |e|
+      @extensions.each do |e|
         result << e.send(method, *args) if e.respond_to? method
       end
       result

--- a/lib/blinkr/engine.rb
+++ b/lib/blinkr/engine.rb
@@ -128,7 +128,7 @@ module Blinkr
 
     def execute(method, *args)
       result = []
-      @extensions.each do |e|
+      Parallel.each(@extensions, :in_threads => Parallel.processor_count * 3) do |e|
         result << e.send(method, *args) if e.respond_to? method
       end
       result

--- a/lib/blinkr/engine.rb
+++ b/lib/blinkr/engine.rb
@@ -37,7 +37,7 @@ module Blinkr
 
     def run
       context = OpenStruct.new({:pages => {}})
-      if defined?(JRUBY_VERSION) && @config.browser == 'manticore'
+      if defined?(JRUBY_VERSION)
         require 'blinkr/manticore_wrapper'
         bulk_browser = browser = ManticoreWrapper.new(@config, context)
       else

--- a/lib/blinkr/extensions/a_title.rb
+++ b/lib/blinkr/extensions/a_title.rb
@@ -1,4 +1,5 @@
 require 'blinkr/error'
+require 'nokogiri'
 
 module Blinkr
   module Extensions
@@ -9,7 +10,7 @@ module Blinkr
       end
 
       def collect page
-        page.body.css('a:not([title])').each do |a|
+        Nokogiri::HTML(page.response.body).freeze.css('a:not([title])').each do |a|
           page.errors << Blinkr::Error.new({:severity => 'info', :category => 'SEO',
                                             :type => '<a title=""> missing',
                                             :title => "#{a['href']} (line #{a.line})",

--- a/lib/blinkr/extensions/empty_a_href.rb
+++ b/lib/blinkr/extensions/empty_a_href.rb
@@ -1,4 +1,5 @@
 require 'blinkr/error'
+require 'nokogiri'
 
 module Blinkr
   module Extensions
@@ -9,7 +10,7 @@ module Blinkr
       end
 
       def collect page
-        page.body.css('a[href]').each do |a|
+        Nokogiri::HTML(page.response.body).freeze.css('a[href]').each do |a|
           if a['href'].empty?
             page.errors << Blinkr::Error.new({:severity => 'info', :category => 'HTML Compatibility/Correctness',
                                               :type => '<a href=""> empty',

--- a/lib/blinkr/extensions/img_alt.rb
+++ b/lib/blinkr/extensions/img_alt.rb
@@ -1,4 +1,5 @@
 require 'blinkr/error'
+require 'nokogiri'
 
 module Blinkr
   module Extensions
@@ -9,7 +10,7 @@ module Blinkr
       end
 
       def collect page
-        page.body.css('img:not([alt])').each do |img|
+        Nokogiri::HTML(page.response.body).freeze.css('img:not([alt])').each do |img|
           page.errors << OpenStruct.new({:severity => 'warning', :category => 'SEO',
                                          :type => '<img alt=""> missing',
                                          :title => "#{img['src']} (line #{img.line})",

--- a/lib/blinkr/extensions/inline_css.rb
+++ b/lib/blinkr/extensions/inline_css.rb
@@ -1,4 +1,5 @@
 require 'blinkr/error'
+require 'nokogiri'
 
 module Blinkr
   module Extensions
@@ -9,7 +10,7 @@ module Blinkr
       end
 
       def collect page
-        page.body.css('[style]').each do |elm|
+        Nokogiri::HTML(page.response.body).freeze.css('[style]').each do |elm|
           if elm['style'] == ""
             page.errors << Blinkr::Error.new({:severity => 'info', :category => 'HTML Compatibility/Correctness',
                                               :type => 'style attribute is empty',

--- a/lib/blinkr/extensions/links.rb
+++ b/lib/blinkr/extensions/links.rb
@@ -55,6 +55,7 @@ module Blinkr
             end
           end
         end
+        puts "Ready to process external links" if @config.verbose
         browser.process_all(external_links.keys, @config.max_retrys, :method => :get, :followlocation => true) do |resp|
           url = (resp.request.url || request.getURI.to_s)
           puts "Loaded #{url} via #{browser.name} #{'(cached)' if resp.cached?}" if @config.verbose

--- a/lib/blinkr/extensions/links.rb
+++ b/lib/blinkr/extensions/links.rb
@@ -56,7 +56,7 @@ module Blinkr
           end
         end
         puts "Ready to process external links" if @config.verbose
-        browser.process_all(external_links.keys, @config.max_retrys, :method => :get, :followlocation => true) do |resp, url|
+        browser.process_all(external_links.keys, @config.max_retrys, :method => :head, :followlocation => true) do |resp, url|
           # if resp.request
           #   url = (resp.request.url || resp.getURI.to_s)
           # else

--- a/lib/blinkr/extensions/links.rb
+++ b/lib/blinkr/extensions/links.rb
@@ -56,7 +56,7 @@ module Blinkr
           end
         end
         puts "Ready to process external links" if @config.verbose
-        browser.process_all(external_links.keys, @config.max_retrys, :method => :head, :followlocation => true) do |resp, url|
+        browser.process_all(external_links.keys, @config.max_retrys, :method => :get, :followlocation => true) do |resp, url|
           # if resp.request
           #   url = (resp.request.url || resp.getURI.to_s)
           # else

--- a/lib/blinkr/extensions/links.rb
+++ b/lib/blinkr/extensions/links.rb
@@ -56,8 +56,12 @@ module Blinkr
           end
         end
         puts "Ready to process external links" if @config.verbose
-        browser.process_all(external_links.keys, @config.max_retrys, :method => :get, :followlocation => true) do |resp|
-          url = (resp.request.url || request.getURI.to_s)
+        browser.process_all(external_links.keys, @config.max_retrys, :method => :get, :followlocation => true) do |resp, url|
+          # if resp.request
+          #   url = (resp.request.url || resp.getURI.to_s)
+          # else
+          #   url = resp.effective_url
+          # end
           puts "Loaded #{url} via #{browser.name} #{'(cached)' if resp.cached?}" if @config.verbose
           if resp.code.to_i < 200 || resp.code.to_i > 300
             response = resp

--- a/lib/blinkr/extensions/links.rb
+++ b/lib/blinkr/extensions/links.rb
@@ -55,40 +55,72 @@ module Blinkr
             end
           end
         end
-        external_links.each do |url, metadata|
-          # if link start_with? @config.base_url check to see if it's in the sitemap.xml
-          browser.process(url, @config.max_retrys, :method => :get, :followlocation => true) do |resp|
-            puts "Loaded #{url} via #{browser.name} #{'(cached)' if resp.cached?}" if @config.verbose
-            if resp.code.to_i < 200 || resp.code.to_i > 300
-              response = resp
+        browser.process_all(external_links.keys, @config.max_retrys, :method => :get, :followlocation => true) do |resp|
+          url = (resp.request.url || request.getURI.to_s)
+          puts "Loaded #{url} via #{browser.name} #{'(cached)' if resp.cached?}" if @config.verbose
+          if resp.code.to_i < 200 || resp.code.to_i > 300
+            response = resp
 
-              metadata.each do |src|
-                detail = nil
-                if response.status_message.nil?
-                  message = response.return_message
-                else
-                  message = response.status_message
-                  detail = response.return_message unless resp.return_message == 'No error'
-                end
-
-                severity = :danger
-                if response.code.to_i >= 300 && response.code.to_i < 400
-                  severity = :warning
-                end
-                src[:page].errors << Blinkr::Error.new({:severity => severity,
-                :category => 'Resources missing',
-                :type => '<a href=""> target cannot be loaded',
-                :url => url, :title => "#{url} (line #{src[:line]})",
-                :code => response.code.to_i, :message => message,
-                :detail => detail, :snippet => src[:snippet],
-                :icon => 'fa-bookmark-o'}) unless response.success?
+            metadata = external_links[url]
+            metadata.each do |src|
+              detail = nil
+              if response.status_message.nil?
+                message = response.return_message
+              else
+                message = response.status_message
+                detail = response.return_message unless resp.return_message == 'No error'
               end
+
+              severity = :danger
+              if response.code.to_i >= 300 && response.code.to_i < 400
+                severity = :warning
+              end
+              src[:page].errors << Blinkr::Error.new({:severity => severity,
+                                                      :category => 'Resources missing',
+                                                      :type => '<a href=""> target cannot be loaded',
+                                                      :url => url, :title => "#{url} (line #{src[:line]})",
+                                                      :code => response.code.to_i, :message => message,
+                                                      :detail => detail, :snippet => src[:snippet],
+                                                      :icon => 'fa-bookmark-o'}) unless response.success?
             end
-            processed += 1
-            puts "Processed #{processed} of #{external_links.size}" if @config.verbose
           end
+          processed += 1
+          puts "Processed #{processed} of #{external_links.size}" if @config.verbose
         end
-        browser.hydra.run if browser.is_a? Blinkr::TyphoeusWrapper
+        # external_links.each do |url, metadata|
+        #   # if link start_with? @config.base_url check to see if it's in the sitemap.xml
+        #   browser.process(url, @config.max_retrys, :method => :get, :followlocation => true) do |resp|
+        #     puts "Loaded #{url} via #{browser.name} #{'(cached)' if resp.cached?}" if @config.verbose
+        #     if resp.code.to_i < 200 || resp.code.to_i > 300
+        #       response = resp
+        #
+        #       metadata.each do |src|
+        #         detail = nil
+        #         if response.status_message.nil?
+        #           message = response.return_message
+        #         else
+        #           message = response.status_message
+        #           detail = response.return_message unless resp.return_message == 'No error'
+        #         end
+        #
+        #         severity = :danger
+        #         if response.code.to_i >= 300 && response.code.to_i < 400
+        #           severity = :warning
+        #         end
+        #         src[:page].errors << Blinkr::Error.new({:severity => severity,
+        #         :category => 'Resources missing',
+        #         :type => '<a href=""> target cannot be loaded',
+        #         :url => url, :title => "#{url} (line #{src[:line]})",
+        #         :code => response.code.to_i, :message => message,
+        #         :detail => detail, :snippet => src[:snippet],
+        #         :icon => 'fa-bookmark-o'}) unless response.success?
+        #       end
+        #     end
+        #     processed += 1
+        #     puts "Processed #{processed} of #{external_links.size}" if @config.verbose
+        #   end
+        # end
+        # browser.hydra.run if browser.is_a? Blinkr::TyphoeusWrapper
       end
 
     end

--- a/lib/blinkr/extensions/meta.rb
+++ b/lib/blinkr/extensions/meta.rb
@@ -1,6 +1,7 @@
 require 'blinkr/error'
 require 'ostruct'
 require 'slim'
+require 'nokogiri'
 
 module Blinkr
   module Extensions
@@ -31,7 +32,7 @@ module Blinkr
       private
 
       def title page
-        elms = page.body.css('title')
+        elms = Nokogiri::HTML(page.response.body).freeze.css('title')
         if elms.length > 1
           snippets = []
           lines = []
@@ -68,7 +69,7 @@ module Blinkr
       end
 
       def description page
-        elms = page.body.css('meta[name=description]')
+        elms = Nokogiri::HTML(page.response.body).freeze.css('meta[name=description]')
         if elms.length > 1
           snippets = []
           lines = []

--- a/lib/blinkr/http_utils.rb
+++ b/lib/blinkr/http_utils.rb
@@ -32,7 +32,7 @@ module Blinkr
 
         dest = dest_uri.to_s
       rescue URI::InvalidURIError, URI::InvalidComponentError, URI::BadURIError
-        # ignored
+        return nil
       rescue StandardError
         return nil
       end

--- a/lib/blinkr/manticore_wrapper.rb
+++ b/lib/blinkr/manticore_wrapper.rb
@@ -2,11 +2,11 @@ require 'manticore'
 require 'blinkr/cache'
 require 'blinkr/http_utils'
 
-module Blinker
+module Blinkr
   class ManticoreWrapper
     include HttpUtils
 
-    attr_reader count
+    attr_reader :count
 
     def initialize(config, context)
       @config = config.validate

--- a/lib/blinkr/typhoeus_wrapper.rb
+++ b/lib/blinkr/typhoeus_wrapper.rb
@@ -91,6 +91,7 @@ module Blinkr
             block.call resp, nil, nil
           end
         end
+        puts "Requesting #{url} via #{name}"
         @hydra.queue req
         @count += 1
       end

--- a/lib/blinkr/typhoeus_wrapper.rb
+++ b/lib/blinkr/typhoeus_wrapper.rb
@@ -74,7 +74,7 @@ module Blinkr
             url,
             opts.merge(:followlocation => true)
         )
-        req.on_complete do |resp|
+        req.on_headers do |resp|
           if retry? resp
             if limit > 1
               puts "Loading #{url} via typhoeus (attempt #{max - limit + 2} of #{max})" if @config.verbose
@@ -85,13 +85,12 @@ module Blinkr
                                                 :mock => true)
               response.request = Typhoeus::Request.new(url)
               Typhoeus.stub(url).and_return(response)
-              block.call response, nil, nil
+              block.call response, url, nil
             end
           else
-            block.call resp, nil, nil
+            block.call resp, url, nil
           end
         end
-        puts "Requesting #{url} via #{name}"
         @hydra.queue req
         @count += 1
       end


### PR DESCRIPTION
These are fixes to support jruby (which is much faster, ~15 minutes on my box vs ~40 for a full run of the below command)

I tested it with: /home/jporter/jruby-9.0.0.0.rc1/bin/jruby -S bundle exec blinkr -c /home/jporter/projects/jboss/www.jboss.org/_config/blinkr.yaml -u http://www-stg.jboss.org/pr/923/build/2170/ -v

You may need to specify a larger heap than the initial 500 MB, but this is promising.