### PR TITLE
Blinkr v0 4 0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,13 @@ source 'https://rubygems.org'
 platform :jruby do
   gem 'manticore'
 end
+
+group(:test, :development) do
+  gem 'minitest', '~> 5.10', '>= 5.10.2'
+  gem 'mocha'
+  gem 'minitest-reporters'
+  gem 'webmock'
+end
+
 # Specify your gem's dependencies in blinkr.gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,28 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
+require 'rake/testtask'
 
-GEMFILE = "blinkr-#{Blinkr::VERSION}.gem"
+GEMFILE = "blinkr-#{Blinkr::VERSION}.gem".freeze
 
-desc "Run all tests and build the gem"
+desc 'Run all unit-tests'
+task :test do |args|
+  Rake::Task[:unit_test_task].invoke(args)
+end
+
+Rake::TestTask.new do |t|
+  t.name = :unit_test_task
+  t.warning = false
+  t.verbose = true
+  t.test_files = FileList['test/unit-test/*.rb', 'test/unit-test/extensions/*.rb']
+end
+
+desc 'Build the gem'
 task :build do
-  system "gem build blinkr.gemspec"
+  system 'gem build blinkr.gemspec'
 end
 
 namespace :release do
-  desc "Release the gem to rubygems"
-  task :push => [ :build, :tag ] do
+  desc 'Release the gem to rubygems'
+  task push: %I[build tag] do
     system "gem push #{GEMFILE}"
   end
 
@@ -18,4 +31,3 @@ namespace :release do
     system "git tag #{Blinkr::VERSION}"
   end
 end
-

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,8 @@ require 'rake/testtask'
 
 GEMFILE = "blinkr-#{Blinkr::VERSION}.gem".freeze
 
+task build: %I[test build_task]
+
 desc 'Run all unit-tests'
 task :test do |args|
   Rake::Task[:unit_test_task].invoke(args)
@@ -16,7 +18,7 @@ Rake::TestTask.new do |t|
 end
 
 desc 'Build the gem'
-task :build do
+task :build_task do
   system 'gem build blinkr.gemspec'
 end
 

--- a/bin/blinkr
+++ b/bin/blinkr
@@ -1,36 +1,47 @@
 #!/usr/bin/env ruby
-
 require 'blinkr'
 require 'optparse'
+Encoding.default_external = 'UTF-8'
 
 options = {}
 
 OptionParser.new do |opts|
-  opts.banner = "Usage: blinkr [options]"
+  opts.banner = 'Usage: blinkr [options]'
 
-  opts.on("-c", "--config FILE", "specify the config.yaml file") do |opt|
-    options[:config] = opt
+  opts.on('-c', '--config FILE', 'specify the config.yaml file') do |opt|
+    options[:config_file] = opt
   end
-  opts.on("-u", "--base-url URL", "specify the URL of the site root") do |opt|
+  opts.on('-u', '--base-url URL', 'specify the URL of the site root') do |opt|
     options[:base_url] = opt
   end
-  opts.on("-v", "--verbose", "output debugging info to the console") do |opt|
+  opts.on('-v', '--verbose', 'output debugging info to the console') do |opt|
     options[:verbose] = opt
   end
-  opts.on("-w", "--very-verbose", "additionally, output libcurl debugging info to the console, normally used with -s") do |opt|
-    options[:vverbose] = opt
+  opts.on('-w', '--very-verbose', 'additionally, output libcurl debugging info to the console, normally used with -s') do |opt|
+    options[:very_verbose] = opt
   end
-  opts.on("-s", "--single-url URL", "test a single URL, outputting the response to the console") do |opt|
+  opts.on('-s', '--single-url URL', 'test a single URL, outputting the response to the console') do |opt|
     options[:single_url] = opt
     options[:base_url] = opt
+  end
+  opts.on('--ignore-external', 'Ignore external links') do |opt|
+    options[:ignore_external] = opt
+  end
+  opts.on('--ignore-internal', 'Ignore internal links') do |opt|
+    options[:ignore_internal] = opt
+  end
+  opts.on('--ignore-ssl', 'Disable SSL certificate checking') do |opt|
+    options[:ignore_ssl] = opt
   end
 end.parse!
 
 require 'blinkr/hacks'
 require 'date'
+require 'blinkr/formatter/default_logger'
+require 'colorize'
+require 'openssl'
+OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE if options[:ignore_ssl]
 start = DateTime.now
-puts "Started at #{start.to_s}"
-Blinkr.run options[:base_url].freeze, options[:config].freeze, options[:single_url].freeze,
-           options[:verbose].freeze, options[:vverbose].freeze
-puts "Total time: #{(DateTime.now.to_time - start.to_time).duration}"
-
+Blinkr.logger.info("Started at #{start}")
+Blinkr.run(options)
+puts("Total time: #{(DateTime.now.to_time - start.to_time).duration}")

--- a/blinkr.gemspec
+++ b/blinkr.gemspec
@@ -1,37 +1,43 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'blinkr/version'
 
 Gem::Specification.new do |spec|
   spec.name = 'blinkr'
-  spec.version       = Blinkr::VERSION
+  spec.version = Blinkr::VERSION
   spec.authors = ['Pete Muir', 'Jason Porter']
-  spec.email = %w(pmuir@bleepbleep.org.uk lightguard.jp@gmail.com)
-  spec.summary       = %q{A simple broken link checker}
-  spec.description   = %q{A broken page and link checker for websites. Optionally uses phantomjs to render pages to check resource loading, links created by JS, and report any JS page load errors.}
+  spec.email = %w[pmuir@bleepbleep.org.uk lightguard.jp@gmail.com]
+  spec.summary = 'A simple broken link checker'
+  spec.description = <<-EOF
+       A broken page and link checker for websites. Optionally uses phantomjs to render pages to check resource loading,
+       links created by JS, and report any JS page load errors.
+  EOF
   spec.homepage = 'https://github.com/pmuir/blinkr'
   spec.license = 'Apache-2.0'
 
-  spec.files         = `git ls-files`.split($/)
-  spec.files         -= ['.gitignore', '.ruby-version', '.ruby-gemset']
+  spec.files = `git ls-files`.split($RS)
+  spec.files -= %w[.gitignore .ruby-version .ruby-gemset]
 
-
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 1.9'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake', '~> 10.3'
-  spec.add_dependency 'nokogiri', '~> 1.5'
-  spec.add_dependency 'typhoeus', '~> 0.7'
-  spec.add_dependency 'slim', '~> 3.0'
-  spec.add_dependency 'parallel', '~> 1.3'
+  spec.add_dependency 'nokogiri', '~> 1.7.2'
+  spec.add_dependency 'typhoeus', '~> 1.1.2'
+  spec.add_dependency 'slim', '~> 3.0.8'
+  spec.add_dependency 'parallel', '~> 1.11.2'
+  spec.add_development_dependency 'rspec'
+  spec.add_runtime_dependency('colorize')
+  spec.add_development_dependency 'fakeweb', ['~> 1.3']
 
   if defined? JRUBY_VERSION
     spec.platform = 'java'
-    spec.add_dependency 'manticore', '~> 0.4'
+    spec.add_dependency 'manticore', '~> 0.6.1'
   end
 end

--- a/lib/blinkr.rb
+++ b/lib/blinkr.rb
@@ -3,24 +3,24 @@ require 'blinkr/engine'
 require 'blinkr/report'
 require 'blinkr/config'
 require 'blinkr/error'
+require 'blinkr/hacks'
 require 'blinkr/typhoeus_wrapper'
 require 'yaml'
 
 module Blinkr
-  def self.run(base_url, config = 'blinkr.yaml', single, verbose, vverbose)
-    args = {:base_url => base_url, :verbose => verbose, :vverbose => vverbose}
-    if !config.nil? && File.exists?(config)
-      config = Blinkr::Config.read config, args
-    else
-      config = Blinkr::Config.new args
-    end
-    
-    if single.nil?
+  module_function
+
+  def self.run(options = {})
+    config = if options[:config_file] && File.exist?(options[:config_file])
+               Blinkr::Config.read(options[:config_file], options.tap { |hs| hs.delete(:config_file) })
+             else
+               Blinkr::Config.new(options)
+             end
+
+    if options[:single_url].nil?
       Blinkr::Engine.new(config).run
     else
-      Blinkr::TyphoeusWrapper.new(config, OpenStruct.new).debug(single)
+      Blinkr::TyphoeusWrapper.new(config, OpenStruct.new).debug(options[:single_url])
     end
   end
-
 end
-

--- a/lib/blinkr/cache.rb
+++ b/lib/blinkr/cache.rb
@@ -9,7 +9,7 @@ module Blinkr
     end
 
     def set(request, response)
-      if request.is_a? String # HACK for caching resource and js errors
+      if request.is_a? String # HACK: for caching resource and js errors
         @memory[request] = response
       else
         @memory[request] = response unless response.timed_out?
@@ -21,4 +21,3 @@ module Blinkr
     end
   end
 end
-

--- a/lib/blinkr/config.rb
+++ b/lib/blinkr/config.rb
@@ -2,31 +2,34 @@ require 'ostruct'
 
 module Blinkr
   class Config < OpenStruct
-
-    def self.read file, args
-      raise "Cannot read #{file}" unless File.exists? file
-      Config.new(YAML.load_file(file).merge(args).merge({ :config_file => file }))
+    def self.read(file, args)
+      raise("Cannot read #{file}") unless File.exist?(file)
+      Config.new(YAML.load_file(file).merge(args).merge(config_file: file))
     end
 
-    DEFAULTS = {:skips => [], :ignores => [], :max_retrys => 3, :browser => 'typhoeus',
-                :viewport => 1200, :phantomjs_threads => 8, :report => 'blinkr.html',
-                :warning_on_300s => false
-               }
+    DEFAULTS = { skips: [], ignores: [], environments: [], max_retrys: 3,
+                browser: 'phantomjs', viewport: 1200, phantomjs_threads: 10,
+                report: 'blinkr.html', warning_on_300s: false,
+                ignore_internal: false, ignore_external: false,
+                warn_js_errors: false, warn_inline_css: false,
+                ignore_ssl: false, warn_resource_errors: false }.freeze
 
-    def initialize(hash={})
+    def initialize(hash = {})
       super(DEFAULTS.merge(hash))
     end
 
     def validate
-      ignores.each {|ignore| raise "An ignore must be a hash" unless ignore.is_a? Hash}
-      raise "Must specify base_url" if base_url.nil?
-      raise "Must specify sitemap" if sitemap.nil?
+      unless single_url
+        ignores.each { |ignore| raise 'An ignore must be a hash' unless ignore.is_a? Hash }
+        raise 'Must specify base_url' if base_url.nil?
+        raise 'Must specify sitemap' if sitemap.nil?
+      end
       self
     end
 
     def sitemap
       if super.nil?
-        URI.join(base_url, 'sitemap.xml').to_s 
+        URI.join(base_url, 'sitemap.xml').to_s
       else
         super
       end
@@ -34,36 +37,52 @@ module Blinkr
 
     def max_page_retrys
       r = super || max_retrys
-      raise "Retrys is nil" if r.nil?
+      raise 'Retrys is nil' if r.nil?
       r
     end
 
-    def ignored? error
+    def ignored?(error)
       url = error.url
       code = error.code
       message = error.message
       snippet = error.snippet
 
       ignores.any? do |ignore|
-	return true if ignore['url'].is_a?(Regexp) && url && ignore['url'] =~ url
-	return true if ignore['url'] == url
 
-        return true if ignore['code'].is_a?(Regexp) && code && ignore['code'] == code
-        return true if ignore['code']  == code
+        if ignore.key? 'url'
+          return true if ignore['url'].is_a?(Regexp) && url && ignore['url'] =~ url
+          return true if ignore['url'] == url
+        end
 
-        return true if ignore['message'].is_a?(Regexp) && message && ignore['message'] =~ message
-        return true if ignore['message']  == message
+        if ignore.key? 'code'
+          return true if ignore['code'].is_a?(Regexp) && code && ignore['code'] == code
+          return true if ignore['code'] == code
+        end
 
-        return true if ignore['snippet'].is_a?(Regexp) && snippet && ignore['snippet'] =~ snippet
-        return true if ignore['snippet'] == snippet
+        if ignore.key? 'message'
+          return true if ignore['message'].is_a?(Regexp) && message && ignore['message'] =~ message
+          return true if ignore['message'] == message
+        end
+
+        if ignore.key? 'snippet'
+          return true if ignore['snippet'].is_a?(Regexp) && snippet && ignore['snippet'] =~ snippet
+          return true if ignore['snippet'] == snippet
+        end
+
         false
       end
     end
 
-    def skipped? url
-      skips.any? { |regex| regex.match(url) }
+    def skipped?(url)
+      if skips.any? do |skip|
+        if skip.is_a?(Regexp)
+          return true if skip =~ url
+        else
+          return true if skip == url
+        end
+      end
+      end
     end
 
   end
 end
-

--- a/lib/blinkr/engine.rb
+++ b/lib/blinkr/engine.rb
@@ -5,6 +5,7 @@ require 'blinkr/slimer_js_wrapper'
 require 'blinkr/http_utils'
 require 'blinkr/sitemap'
 require 'blinkr/report'
+require 'blinkr/formatter/default_logger'
 require 'blinkr/extensions/links'
 require 'blinkr/extensions/javascript'
 require 'blinkr/extensions/resources'
@@ -16,66 +17,73 @@ require 'ostruct'
 
 # Monkeypatch OpenStruct
 class OpenStruct
+  EXCEPT = %I[response body resource_errors javascript_errors].freeze
 
-  EXCEPT = [:response, :body, :resource_errors, :javascript_errors]
-  
   def to_json(*args)
-    to_h.delete_if{ |k, v| EXCEPT.include?(k) }.to_json(*args)
+    to_h.delete_if { |k, _v| EXCEPT.include?(k) }.to_json(*args)
   end
-
 end
 
 module Blinkr
-  class Engine 
+  class Engine
     include HttpUtils
-    include Sitemap
 
     def initialize(config)
       @config = config.validate
       @extensions = []
+      @logger = Blinkr.logger
       load_pipeline
     end
 
     def run
-      context = OpenStruct.new({:pages => {}})
-      if defined?(JRUBY_VERSION) && @config.browser == 'manticore'
-        require 'blinkr/manticore_wrapper'
-        bulk_browser = browser = ManticoreWrapper.new(@config, context)
-      else
-        bulk_browser = browser = TyphoeusWrapper.new(@config, context)
-      end
-      browser = PhantomJSWrapper.new(@config, context) if @config.browser == 'phantomjs'
-      browser = SlimerJSWrapper.new(@config, context) if @config.browser == 'slimerjs'
+      context = OpenStruct.new(pages: {})
+
+      bulk_browser, browser = define_browser(context)
       page_count = 0
-      urls = sitemap_locations.uniq
-      puts "Fetching #{urls.size} pages from sitemap"
+      urls = Sitemap.new(@config).sitemap_locations.uniq
+
+      @logger.info("Fetching #{urls.size} pages from sitemap".yellow)
       browser.process_all(urls, @config.max_page_retrys) do |response, resource_errors, javascript_errors|
         url = response.request.base_url
         if response.success?
-          puts "Loaded page #{url}" if @config.verbose
+          @logger.info("Loaded page #{url}".green) if @config.verbose
           body = Nokogiri::HTML(response.body)
-          page = OpenStruct.new({:response => response, :body => body.freeze,
-                                 :errors => ErrorArray.new(@config),
-                                 :resource_errors => resource_errors || [],
-                                 :javascript_errors => javascript_errors || []})
+          page = OpenStruct.new(response: response,
+                                body: body.freeze,
+                                errors: ErrorArray.new(@config),
+                                resource_errors: resource_errors || [],
+                                javascript_errors: javascript_errors || [])
           context.pages[url] = page
-          collect page
+          collect(page)
           page_count += 1
         else
-          puts "#{response.code} #{response.status_message} Unable to load page #{url} #{'(' + response.return_message + ')' unless response.return_message.nil?}"
+          @logger.info("#{response.code} #{response.status_message} Unable to load page #{url} #{'(' + response.return_message + ')' unless response.return_message.nil?}".red)
         end
       end
-      puts 'Executing Typhoeus::Hydra.run, this could take awhile' if @config.browser == 'typhoeus'
-      # browser.hydra.run if @config.browser == 'typhoeus'
-      puts "Loaded #{page_count} pages using #{browser.name}."
-      puts 'Analyzing pages'
-      analyze context, bulk_browser
+      @logger.info('Executing Typhoeus::Hydra.run, this could take awhile'.magenta) if @config.browser == 'typhoeus'
+      @logger.info("Loaded #{page_count} pages using #{browser.name}.".green)
+      @logger.info('Analyzing pages'.yellow)
+      analyze(context, bulk_browser)
       context.pages.reject! { |_, page| page.errors.empty? }
 
       unless @config.export.nil?
         FileUtils.mkdir_p Pathname.new(@config.report).parent
       end
       Blinkr::Report.new(context, self, @config).render
+    end
+
+    # generate user-defined browser to use for duration of checks
+    # if using Jruby defaults to Manticore, else uses Typhoeus.
+    def define_browser(context)
+      if defined?(JRUBY_VERSION)
+        require 'blinkr/manticore_wrapper'
+        bulk_browser = browser = ManticoreWrapper.new(@config, context)
+      else
+        bulk_browser = browser = TyphoeusWrapper.new(@config, context)
+      end
+      browser = SlimerJSWrapper.new(@config, context) if @config.browser == 'slimerjs'
+      browser = PhantomJSWrapper.new(@config, context) if @config.browser == 'phantomjs'
+      return bulk_browser, browser
     end
 
     def append(context)
@@ -103,7 +111,6 @@ module Blinkr
     private
 
     class ErrorArray < Array
-
       def initialize(config)
         @config = config
       end
@@ -115,7 +122,6 @@ module Blinkr
           super
         end
       end
-
     end
 
     def extension(ext)
@@ -138,26 +144,24 @@ module Blinkr
 
     def load_pipeline
       if @config.pipeline.nil?
-        puts 'Loaded default pipeline' if @config.verbose
+        @logger.info('Loaded default pipeline'.yellow) if @config.verbose
         default_pipeline
       else
         pipeline_file = File.join(File.dirname(@config.config_file), @config.pipeline)
-        if File.exists?(pipeline_file)
+        if File.exist?(pipeline_file)
           p = eval(File.read(pipeline_file), nil, pipeline_file, 1).load @config
           p.extensions.each do |e|
             extension(e)
           end
           if @config.verbose
-            puts "Loaded custom pipeline from #{@config.pipeline}"
+            @logger.info("Loaded custom pipeline from #{@config.pipeline}".yellow)
             pipeline = @extensions.inject { |memo, v| "#{memo}, #{v}" }
-            puts "Pipeline: #{pipeline}"
+            @logger.info("Pipeline: #{pipeline}".yellow)
           end
         else
           raise "Cannot find pipeline file #{pipeline_file}"
         end
       end
     end
-
   end
 end
-

--- a/lib/blinkr/error.rb
+++ b/lib/blinkr/error.rb
@@ -1,12 +1,11 @@
 module Blinkr
-  SEVERITY = [:success, :info, :warning, :danger]
+  SEVERITY = %I[success info warning danger].freeze
   class Error
     attr_reader :severity, :category, :type, :title, :message, :snippet, :icon, :code, :detail, :url
 
-    def initialize (opts = {})
+    def initialize(opts = {})
       raise TypeError 'severity must be a string or symbol' unless opts[:severity].is_a?(String) || opts[:severity].is_a?(Symbol)
       raise 'severity not a recognized value' unless SEVERITY.include? opts[:severity].to_sym
-
       @severity = opts[:severity].to_sym
       @category = opts[:category]
       @type = opts[:type]

--- a/lib/blinkr/extensions/a_title.rb
+++ b/lib/blinkr/extensions/a_title.rb
@@ -3,21 +3,20 @@ require 'blinkr/error'
 module Blinkr
   module Extensions
     class ATitle
-
-      def initialize config
+      def initialize(config)
         @config = config
       end
 
-      def collect page
+      def collect(page)
         page.body.css('a:not([title])').each do |a|
-          page.errors << Blinkr::Error.new({:severity => 'info', :category => 'SEO',
-                                            :type => '<a title=""> missing',
-                                            :title => "#{a['href']} (line #{a.line})",
-                                            :message => '<a title=""> missing',
-                                            :snippet => a.to_s, :icon => 'fa-info'})
+          page.errors << Blinkr::Error.new(severity: 'info',
+                                           category: 'SEO',
+                                           type: '<a title=""> missing',
+                                           title: "#{a['href']} (line #{a.line})",
+                                           message: '<a title=""> missing',
+                                           snippet: a.to_s, icon: 'fa-info')
         end
       end
-
     end
   end
 end

--- a/lib/blinkr/extensions/empty_a_href.rb
+++ b/lib/blinkr/extensions/empty_a_href.rb
@@ -3,23 +3,23 @@ require 'blinkr/error'
 module Blinkr
   module Extensions
     class EmptyAHref
-
-      def initialize config
+      def initialize(config)
         @config = config
       end
 
-      def collect page
+      def collect(page)
         page.body.css('a[href]').each do |a|
           if a['href'].empty?
-            page.errors << Blinkr::Error.new({:severity => 'info', :category => 'HTML Compatibility/Correctness',
-                                              :type => '<a href=""> empty',
-                                              :title => %Q{<a href=""> empty (line #{a.line})},
-                                              :message => %Q{<a href=""> empty}, :snippet => a.to_s,
-                                              :icon => 'fa-info'})
+            page.errors << Blinkr::Error.new(severity: 'info',
+                                             category: 'HTML Compatibility/Correctness',
+                                             type: '<a href=""> empty',
+                                             title: %(<a href=''> empty (line #{a.line})),
+                                             message: %(<a href=''> empty),
+                                             snippet: a.to_s,
+                                             icon: 'fa-info')
           end
         end
       end
-
     end
   end
 end

--- a/lib/blinkr/extensions/img_alt.rb
+++ b/lib/blinkr/extensions/img_alt.rb
@@ -3,21 +3,20 @@ require 'blinkr/error'
 module Blinkr
   module Extensions
     class ImgAlt
-
-      def initialize config
+      def initialize(config)
         @config = config
       end
 
-      def collect page
+      def collect(page)
         page.body.css('img:not([alt])').each do |img|
-          page.errors << ::Blinkr::Error.new({:severity => :warning, :category => 'SEO',
-                                         :type => '<img alt=""> missing',
-                                         :title => "#{img['src']} (line #{img.line})",
-                                         :message => '<img alt=""> missing', :snippet => img.to_s,
-                                         :icon => 'fa-info'})
+          page.errors << ::Blinkr::Error.new(severity: :warning,
+                                             category: 'SEO',
+                                             type: '<img alt=""> missing',
+                                             title: "#{img['src']} (line #{img.line})",
+                                             message: '<img alt=""> missing', snippet: img.to_s,
+                                             icon: 'fa-info')
         end
       end
-
     end
   end
 end

--- a/lib/blinkr/extensions/inline_css.rb
+++ b/lib/blinkr/extensions/inline_css.rb
@@ -3,32 +3,31 @@ require 'blinkr/error'
 module Blinkr
   module Extensions
     class InlineCss
-
-      def initialize config
+      def initialize(config)
         @config = config
       end
 
-      def collect page
+      def collect(page)
         page.body.css('[style]').each do |elm|
           elm_clone = Nokogiri.make(elm.to_s)
-          elm_clone.inner_html = ""
-          if elm['style'] == ""
-            page.errors << Blinkr::Error.new({:severity => 'info', :category => 'HTML Compatibility/Correctness',
-                                              :type => 'style attribute is empty',
-                                              :title => %Q{"#{elm['style']}" (line #{elm.line})},
-                                              :message => 'style attribute is empty', :snippet => elm_clone.to_s,
-                                              :icon => 'fa-info'})
-          else
-            page.errors << Blinkr::Error.new({:severity => 'info',
-                                              :category => 'HTML Compatibility/Correctness',
-                                              :type => 'Inline CSS detected',
-                                              :title => %Q{"#{elm['style']}" (line #{elm.line})},
-                                              :message => 'inline style', :snippet => elm_clone.to_s,
-                                              :icon => 'fa-info'})
-          end
+          elm_clone.inner_html = ''
+          page.errors << if elm['style'] == ''
+                           Blinkr::Error.new(severity: 'info',
+                                             category: 'HTML Compatibility/Correctness',
+                                             type: 'style attribute is empty',
+                                             title: %{"#{elm['style']}" (line #{elm.line})},
+                                             message: 'style attribute is empty', snippet: elm_clone.to_s,
+                                             icon: 'fa-info')
+                         else
+                           Blinkr::Error.new(severity: 'info',
+                                             category: 'HTML Compatibility/Correctness',
+                                             type: 'Inline CSS detected',
+                                             title: %{"#{elm['style']}" (line #{elm.line})},
+                                             message: 'inline style', snippet: elm_clone.to_s,
+                                             icon: 'fa-info')
+                         end if @config.warn_inline_css
         end
       end
-
     end
   end
 end

--- a/lib/blinkr/extensions/javascript.rb
+++ b/lib/blinkr/extensions/javascript.rb
@@ -3,19 +3,17 @@ require 'blinkr/error'
 module Blinkr
   module Extensions
     class JavaScript
-
-      def initialize config
+      def initialize(config)
         @config = config
       end
 
-      def collect page
+      def collect(page)
         page.javascript_errors.each do |error|
-          page.errors << Blinkr::Error.new(:severity => 'danger', :category => 'JavaScript',
-                                           :type => 'JavaScript error', :title => error['msg'],
-                                           :snippet => error['trace'], :icon => 'fa-gears')
-        end
+          page.errors << Blinkr::Error.new(severity: 'danger', category: 'JavaScript',
+                                           type: 'JavaScript error', title: error['msg'],
+                                           snippet: error['trace'], icon: 'fa-gears')
+        end if @config.warn_js_errors
       end
-
     end
   end
 end

--- a/lib/blinkr/extensions/links.rb
+++ b/lib/blinkr/extensions/links.rb
@@ -4,69 +4,135 @@ require 'blinkr/http_utils'
 
 module Blinkr
   module Extensions
+    # This class is used to collect and analyze links that are present on the page,
+    # raise errors if links are broken, missing from sitemap, as well as user-configured errors/warnings.
     class Links
       include Blinkr::HttpUtils
 
       def initialize(config)
         @config = config
         @links = {}
+        @logger = Blinkr.logger
       end
 
+      # Collect all hrefs and return links and their location on page.
       def collect(page)
         page.body.css('a[href]').each do |a|
           attr = a.attribute('href')
           src = page.response.effective_url
           url = attr.value
           unless @config.skipped?(url)
-            url = sanitize url, src
+            url = sanitize(url, src)
             unless url.nil?
               @links[url] ||= []
-              @links[url] << {:page => page, :line => attr.line, :snippet => attr.parent.to_s}
+              @links[url] << { page: page, line: attr.line, snippet: attr.parent.to_s }
             end
           end
         end
+        @links
       end
 
       def analyze(context, browser)
-        puts '----------------------'
-        puts " #{@links.length} links to check "
-        puts '----------------------'
+        @logger.info("Found #{@links.length} links".yellow)
         start = DateTime.now
 
-        processed = 0
-
-        # Find the internal links
-        @links.select{|k| k.start_with? @config.base_url}.each do |url, locations|
-          # TODO figure out what to do about relative links
-          link = URI.parse(url)
-
-          # fix up links so they're proper, also drop fragments and queries as they won't be in the sitemap that way
-          link.fragment = nil
-          link.query = nil
-          link.path = link.path.gsub(/\/+/, '/') if link.path
-
-          unless context.pages.keys.include?(link.to_s) || context.pages.keys.include?((link.to_s + '/'))
-            locations.each do |location|
-              location[:page].errors << Blinkr::Error.new({:severity => :warning,
-                                                           :category => 'Resource missing from sitemap',
-                                                           :type => '<a href=""> target missing from sitemap',
-                                                           :url => url, :title => "#{url} (line #{location[:line]})",
-                                                           :code => nil,
-                                                           :message => 'Missing from sitemap',
-                                                           :detail => 'Checked with Typheous',
-                                                           :snippet => location[:snippet],
-                                                           :icon => 'fa-bookmark-o'
-                                                          })
-              # It wasn't in the sitemap, so we'll add it to the "external_links" to still be checked
+        # warn if internal links do not exist within sitemap
+        unless @config.ignore_internal
+          internal_links = @links.select { |k| k.start_with? @config.base_url }
+          internal_links.each do |url, locations|
+            link = fixup_link(url)
+            unless context.pages.keys.include?(link.to_s) || context.pages.keys.include?("#{link}/")
+              locations.each do |location|
+                location[:page].errors << Blinkr::Error.new(severity: :warning,
+                                                            category: 'Resource missing from sitemap',
+                                                            type: '<a href=""> target missing from sitemap',
+                                                            url: link.to_s,
+                                                            title: "#{link} (line #{location[:line]})",
+                                                            code: nil,
+                                                            message: 'Missing from sitemap',
+                                                            detail: 'Checked with Typheous',
+                                                            snippet: location[:snippet],
+                                                            icon: 'fa-bookmark-o')
+              end
             end
           end
         end
-        @links.each do |url, metadata|
-          # if link start_with? @config.base_url check to see if it's in the sitemap.xml
-          browser.process(url, @config.max_retrys, :method => :get, :followlocation => true, :timeout => 60,
-                                                   :cookiefile => '_tmp/cookies', :cookiejar => '_tmp/cookies',
-                          :connecttimeout => 30, :maxredirs => 3) do |resp|
-            puts "Loaded #{url} via #{browser.name} #{'(cached)' if resp.cached?}" if @config.verbose
+
+        unless @config.environments.empty?
+          # Raise an error if links contain user specified environment urls.
+          # For example in a staging environment you may wish to warn/error
+          # if links are incorrectly linking to a production environment.
+          @links.each do |url, locations|
+            if @config.environments.kind_of?(Array)
+              @config.environments.each do |env|
+                if url.to_s.include?(env)
+                  locations.each do |location|
+                    location[:page].errors << Blinkr::Error.new(severity: :danger,
+                                                                category: 'Incorrect Environment',
+                                                                type: '<a href=""> target is incorrect environment',
+                                                                url: url.to_s,
+                                                                title: "#{url} (line #{location[:line]})",
+                                                                code: nil,
+                                                                message: 'Incorrect Environment',
+                                                                detail: 'Checked with Typheous',
+                                                                snippet: location[:snippet],
+                                                                icon: 'fa-bookmark-o')
+                  end
+                end
+              end
+            else
+              if url.to_s.include?(@config.environments)
+                locations.each do |location|
+                  location[:page].errors << Blinkr::Error.new(severity: :danger,
+                                                              category: 'Incorrect Environment',
+                                                              type: '<a href=""> target is incorrect environment',
+                                                              url: url.to_s,
+                                                              title: "#{url} (line #{location[:line]})",
+                                                              code: nil,
+                                                              message: 'Incorrect Environment',
+                                                              detail: 'Checked with Typheous',
+                                                              snippet: location[:snippet],
+                                                              icon: 'fa-bookmark-o')
+                end
+              end
+            end
+          end
+        end
+
+        if @config.ignore_external
+          @logger.info('Ignoring external links')
+          internal_links = @links.select { |k| k.start_with? @config.base_url }
+          check_links(browser, internal_links)
+        elsif @config.ignore_internal
+          @logger.info('Ignoring internal links')
+          external_links = @links.reject { |k| k.start_with? @config.base_url }
+          check_links(browser, external_links)
+        else
+          @logger.info('Checking internal and external links')
+          check_links(browser, @links)
+        end
+
+        @logger.info("Total time to check links: #{(DateTime.now.to_time - start.to_time).duration}") if @config.verbose
+
+      end
+
+      private
+      def fixup_link(url)
+        link = URI.parse(url)
+        link.fragment = nil
+        link.query = nil
+        link.path = link.path.gsub(%r{/\/+/}, '/') if link.path
+        url = URI.parse(@config.base_url).merge(link).to_s
+        url.chomp('/') if url[-1, 1] == '/'
+      end
+
+      def check_links(browser, links)
+        processed = 0
+        @logger.info("Checking #{links.length} links".yellow)
+        links.each do |url, metadata|
+          browser.process(url, @config.max_retrys, method: :get, followlocation: true, timeout: 60, cookiefile: '_tmp/cookies',
+                          cookiejar: '_tmp/cookies', connecttimeout: 30, maxredirs: 3) do |resp|
+            @logger.info("Loaded #{url} via #{browser.name} #{'(cached)' if resp.cached?}".green) if @config.verbose
 
             resp_code = resp.code.to_i
             if ((resp_code > 300 && resp_code < 400) && @config.warning_on_300s) || resp_code > 400
@@ -84,25 +150,23 @@ module Blinkr
               if response.code.to_i >= 300 && response.code.to_i < 400
                 severity = :warning
               end
+
               metadata.each do |src|
-                src[:page].errors << Blinkr::Error.new({:severity => severity,
-                                                        :category => 'Resources missing',
-                                                        :type => '<a href=""> target cannot be loaded',
-                                                        :url => url, :title => "#{url} (line #{src[:line]})",
-                                                        :code => response.code.to_i, :message => message,
-                                                        :detail => detail, :snippet => src[:snippet],
-                                                        :icon => 'fa-bookmark-o'}) unless response.success?
+                src[:page].errors << Blinkr::Error.new(severity: severity,
+                                                       category: 'Broken link',
+                                                       type: '<a href=""> target cannot be loaded',
+                                                       url: url, title: "#{url} (line #{src[:line]})",
+                                                       code: response.code.to_i, message: message,
+                                                       detail: detail, snippet: src[:snippet],
+                                                       icon: 'fa-bookmark-o') unless response.success?
               end
             end
             processed += 1
-            puts "Processed #{processed} of #{@links.size}" if @config.verbose
+            @logger.info("Processed #{processed} of #{links.size}".yellow) if @config.verbose
           end
         end
         browser.hydra.run if browser.is_a? Blinkr::TyphoeusWrapper
-        puts "Total time in links: #{(DateTime.now.to_time - start.to_time).duration}" if @config.verbose
       end
-
     end
   end
 end
-

--- a/lib/blinkr/extensions/meta.rb
+++ b/lib/blinkr/extensions/meta.rb
@@ -4,32 +4,31 @@ require 'slim'
 module Blinkr
   module Extensions
     class Meta
-
       TMPL = File.expand_path('meta.html.slim', File.dirname(__FILE__))
 
-      def initialize config
+      def initialize(config)
         @config = config
         @descriptions = {}
         @titles = {}
       end
 
-      def collect page
-        description page
-        title page
+      def collect(page)
+        description(page)
+        title(page)
       end
 
-      def analyze context, typhoeus
-        context.duplicate_descriptions = @descriptions.reject{ |description, pages| pages.length <= 1 }
-        context.duplicate_titles = @titles.reject{ |title, pages| pages.length <= 1 }
+      def analyze(context, _typhoeus)
+        context.duplicate_descriptions = @descriptions.reject { |_description, pages| pages.length <= 1 }
+        context.duplicate_titles = @titles.reject { |_title, pages| pages.length <= 1 }
       end
 
-      def append context
-        Slim::Template.new(TMPL).render(OpenStruct.new({ :descriptions => context.duplicate_descriptions, :titles => context.duplicate_titles }))
+      def append(context)
+        Slim::Template.new(TMPL).render(OpenStruct.new(descriptions: context.duplicate_descriptions, titles: context.duplicate_titles))
       end
 
       private
 
-      def title page
+      def title(page)
         elms = page.body.css('title')
         if elms.length > 1
           snippets = []
@@ -38,35 +37,35 @@ module Blinkr
             lines << elm.line
             snippets << elm.to_s
           end
-          page.errors << Blinkr::Error.new({:severity => :danger, :category => 'HTML Compatibility/Correctness',
-                                            :type => '<title> tag declared more than once',
-                                            :title => %Q{<title> declared more than once (lines #{lines.join(', ')})},
-                                            :message => %Q{<title> declared more than onc},
-                                            :snippet => snippets.join('\n'), :icon => 'fa-header'})
+          page.errors << Blinkr::Error.new(severity: :danger, category: 'HTML Compatibility/Correctness',
+                                           type: '<title> tag declared more than once',
+                                           title: %(<title> declared more than once (lines #{lines.join(', ')})),
+                                           message: %(<title> declared more than once),
+                                           snippet: snippets.join('\n'), icon: 'fa-header')
         elsif elms.empty?
-          page.errors << Blinkr::Error.new({:severity => :warning, :category => 'SEO', :type => '<title> tag missing',
-                                            :title => %Q{<title> tag missing}, :message => %Q{<title> tag missing},
-                                            :icon => 'fa-header'})
+          page.errors << Blinkr::Error.new(severity: :warning, category: 'SEO', type: '<title> tag missing',
+                                           title: %(<title> tag missing), message: %(<title> tag missing),
+                                           icon: 'fa-header')
         else
           title = elms.first.text
           @titles[title] ||= {}
           @titles[title][page.response.effective_url] = page
           if title.length < 20
-            page.errors << Blinkr::Error.new({:severity => :warning, :category => 'SEO', :type => 'page title too short',
-                                              :title => %Q{<title> too short (line #{elms.first.line})},
-                                              :message => %Q{<title> too short (< 20 characters)},
-                                              :snippet => elms.first.to_s, :icon => 'fa-header'})
+            page.errors << Blinkr::Error.new(severity: :warning, category: 'SEO', type: 'page title too short',
+                                             title: %(<title> too short (line #{elms.first.line})),
+                                             message: %(<title> too short (< 20 characters)),
+                                             snippet: elms.first.to_s, icon: 'fa-header')
           end
           if title.length > 55
-            page.errors << Blinkr::Error.new({:severity => :warning, :category => 'SEO', :type => 'page title too long',
-                                              :title => %Q{<title> too long (line #{elms.first.line})},
-                                              :message => %Q{<title> too long (> 55 characters)},
-                                              :snippet => elms.first.to_s, :icon => 'fa-header'})
+            page.errors << Blinkr::Error.new(severity: :warning, category: 'SEO', type: 'page title too long',
+                                             title: %(<title> too long (line #{elms.first.line})),
+                                             message: %(<title> too long (> 55 characters)),
+                                             snippet: elms.first.to_s, icon: 'fa-header')
           end
         end
       end
 
-      def description page
+      def description(page)
         elms = page.body.css('meta[name=description]')
         if elms.length > 1
           snippets = []
@@ -75,38 +74,37 @@ module Blinkr
             lines << elm.line
             snippets << elm.to_s
           end
-          page.errors << Blinkr::Error.new({:severity => :danger, :category => 'HTML Compatibility/Correctness',
-                                            :type => '<meta name="description"> tag declared more than once',
-                                            :title => %Q{<meta name="description"> tag declared more than once (lines #{lines.join(', ')})},
-                                            :message => %Q{<meta name="description"> tag declared more than once},
-                                            :snippet => snippets.join('\n'), :icon => 'fa-header'})
+          page.errors << Blinkr::Error.new(severity: :danger, category: 'HTML Compatibility/Correctness',
+                                           type: '<meta name="description"> tag declared more than once',
+                                           title: %(<meta name="description"> tag declared more than once (lines #{lines.join(', ')})),
+                                           message: %(<meta name="description"> tag declared more than once),
+                                           snippet: snippets.join('\n'), icon: 'fa-header')
         elsif elms.empty?
-          page.errors << Blinkr::Error.new({:severity => :warning, :category => 'SEO',
-                                            :type => '<meta name="description"> tag missing',
-                                            :title => %Q{<meta name="description"> tag missing},
-                                            :message => %Q{<meta name="description"> tag missing},
-                                            :icon => 'fa-header'})
+          page.errors << Blinkr::Error.new(severity: :warning, category: 'SEO',
+                                           type: '<meta name="description"> tag missing',
+                                           title: %(<meta name="description"> tag missing),
+                                           message: %(<meta name="description"> tag missing),
+                                           icon: 'fa-header')
         else
           desc = elms.first['content']
           @descriptions[desc] ||= {}
           @descriptions[desc][page.response.effective_url] = page
           if desc.length < 60
-            page.errors << Blinkr::Error.new({:severity => :warning, :category => 'SEO',
-                                              :type => '<meta name="description"> too short',
-                                              :title => %Q{<meta name="description"> too short (lines #{elms.first.line})},
-                                              :message => %Q{<meta name="description"> too short (< 60 characters)},
-                                              :snippet => elms.first.to_s, :icon => 'fa-header'})
+            page.errors << Blinkr::Error.new(severity: :warning, category: 'SEO',
+                                             type: '<meta name="description"> too short',
+                                             title: %(<meta name="description"> too short (lines #{elms.first.line})),
+                                             message: %{<meta name="description"> too short (< 60 characters)},
+                                             snippet: elms.first.to_s, icon: 'fa-header')
           end
           if desc.length > 115
-            page.errors << Blinkr::Error.new({:severity => :warning, :category => 'SEO',
-                                              :type => '<meta name="description"> too long',
-                                              :title => %Q{<meta name="description"> too long (lines #{elms.first.line})},
-                                              :message => %Q{<meta name="description"> too long (> 115 characters)},
-                                              :snippet => elms.first.to_s, :icon => 'fa-header'})
+            page.errors << Blinkr::Error.new(severity: :warning, category: 'SEO',
+                                             type: '<meta name="description"> too long',
+                                             title: %(<meta name="description"> too long (lines #{elms.first.line})),
+                                             message: %(<meta name="description"> too long (> 115 characters)),
+                                             snippet: elms.first.to_s, icon: 'fa-header')
           end
         end
       end
-
     end
   end
 end

--- a/lib/blinkr/extensions/pipeline.rb
+++ b/lib/blinkr/extensions/pipeline.rb
@@ -1,4 +1,4 @@
-Dir[ File.join( File.dirname(__FILE__), '*.rb' ) ].each do |f|
+Dir[File.join(File.dirname(__FILE__), '*.rb')].each do |f|
   begin
     require f
   rescue LoadError => e
@@ -11,7 +11,6 @@ end
 module Blinkr
   module Extensions
     class Pipeline
-
       attr_reader :extensions
 
       def initialize(&block)
@@ -19,21 +18,17 @@ module Blinkr
         @block = block
       end
 
-      def load config
-        begin
-          instance_exec config, &@block if @block && @block.arity == 1
-          instance_exec &@block if @block && @block.arity == 0
-          self
-        rescue Exception => e
-          abort("Failed to initialize pipeline: #{e}")
-        end
+      def load(config)
+        instance_exec(config, &@block) if @block && @block.arity == 1
+        instance_exec(&@block) if @block && @block.arity.zero?
+        self
+      rescue StandardError => e
+        abort("Failed to initialize pipeline: #{e}")
       end
 
       def extension(ext)
         @extensions << ext
       end
-
     end
   end
 end
-

--- a/lib/blinkr/extensions/resources.rb
+++ b/lib/blinkr/extensions/resources.rb
@@ -3,22 +3,20 @@ require 'blinkr/error'
 module Blinkr
   module Extensions
     class Resources
-
-      def initialize config
+      def initialize(config)
         @config = config
       end
 
-      def collect page
+      def collect(page)
         page.resource_errors.each do |error|
           start = error['errorString'].rindex('server replied: ')
           message = error['errorString'].slice(start.nil? ? 0 : start + 16, error['errorString'].length) unless error['errorString'].nil?
           code = error['errorCode'].nil? ? nil : error['errorCode'].to_i
-          page.errors << Blinkr::Error.new(:severity => 'danger', :category => 'Resources missing',
-                                           :type => 'Resource loading error', :title => error['url'],
-                                           :code => code, :message => message, :icon => 'fa-file-image-o')
+          page.errors << Blinkr::Error.new(severity: 'danger', category: 'Resources missing',
+                                           type: 'Resource loading error', title: error['url'],
+                                           code: code, message: message, icon: 'fa-file-image-o') if @config.warn_resource_errors
         end
       end
-
     end
   end
 end

--- a/lib/blinkr/formatter/default_logger.rb
+++ b/lib/blinkr/formatter/default_logger.rb
@@ -1,0 +1,13 @@
+require 'colorize'
+
+module Blinkr
+  class << self
+    attr_writer :logger
+
+    def logger
+      @logger ||= Logger.new($stdout).tap do |log|
+        log.progname = name
+      end
+    end
+  end
+end

--- a/lib/blinkr/hacks.rb
+++ b/lib/blinkr/hacks.rb
@@ -1,8 +1,8 @@
 class Numeric
   def duration
-    rest, secs = self.divmod( 60 )  # self is the time difference t2 - t1
-    rest, mins = rest.divmod( 60 )
-    days, hours = rest.divmod( 24 )
+    rest, secs = self.divmod(60) # self is the time difference t2 - t1
+    rest, mins = rest.divmod(60)
+    days, hours = rest.divmod(24)
 
     # the above can be factored out as:
     # days, hours, mins, secs = self.duration_as_arr

--- a/lib/blinkr/http_utils.rb
+++ b/lib/blinkr/http_utils.rb
@@ -2,9 +2,8 @@ require 'uri'
 
 module Blinkr
   module HttpUtils
-
     def sanitize(dest, src)
-      return nil if (dest.nil? || src.nil?)
+      return nil if dest.nil? || src.nil?
 
       # src is the page that tried to load the URL
       # URI fails to handle #! style fragments, so we chomp them
@@ -19,7 +18,6 @@ module Blinkr
       base_uri = URI(@config.base_url)
 
       begin
-
         # dest is the URL we are trying to load
         dest_uri = URI(dest)
         dest_uri.fragment = nil if @config.ignore_fragments
@@ -32,29 +30,27 @@ module Blinkr
 
         # switch multiple '/' to just one. Those types of URIs don't affect the browser,
         # but they do affect our checking
-        dest_uri.path = dest_uri.path.gsub(/\/+/, '/') if dest_uri.path
-        dest_uri.query = dest_uri.query.gsub(/\/+/, '/') if dest_uri.query
-        dest_uri.fragment = dest_uri.query.gsub(/\/+/, '/') if dest_uri.fragment
+        dest_uri.path = dest_uri.path.gsub(%r{/\/+/}, '/') if dest_uri.path
+        dest_uri.query = dest_uri.query.gsub(%r{/\/+/}, '/') if dest_uri.query
+        dest_uri.fragment = dest_uri.query.gsub(%r{/\/+/}, '/') if dest_uri.fragment
 
         dest = dest_uri.to_s
       rescue URI::InvalidURIError, URI::InvalidComponentError, URI::BadURIError
-        # ignored
+        return nil
       rescue StandardError
         return nil
       end
       dest.chomp('#').chomp('index.html')
     end
 
-    def retry? resp
-      resp.timed_out? || (resp.code == 0 && [ "Server returned nothing (no headers, no data)", "SSL connect error", "Failure when receiving data from the peer" ].include?(resp.return_message) )
+    def retry?(resp)
+      resp.timed_out? || (resp.code == 0 && ['Server returned nothing (no headers, no data)', 'SSL connect error', 'Failure when receiving data from the peer'].include?(resp.return_message))
     end
 
     private
-    
-    def empty? str
+
+    def empty?(str)
       str.nil? || str.empty?
     end
- 
   end
 end
-

--- a/lib/blinkr/manticore_wrapper.rb
+++ b/lib/blinkr/manticore_wrapper.rb
@@ -2,30 +2,29 @@ require 'manticore'
 require 'blinkr/cache'
 require 'blinkr/http_utils'
 
-module Blinker
+module Blinkr
   class ManticoreWrapper
     include HttpUtils
 
-    attr_reader count
+    attr_reader :count
 
     def initialize(config, context)
       @config = config.validate
-      @client = Manticore::Client.new({:pool_max => (@config.maxconnects || 50),
-                                       :pool_max_per_route => 10
-                                      })
+      @client = Manticore::Client.new(pool_max: (@config.maxconnects || 50), pool_max_per_route: 10)
       @count = 0
       @context = context
+      @logger = Blinkr.logger
     end
 
     def process_all(urls, limit, opts = {}, &block)
       urls.each do |url|
-        process url, limit, opts, &block
+        process(url, limit, opts, &block)
       end
       @client.execute!
     end
 
     def process(url, limit, opts = {}, &block)
-      _process url, limit, limit, opts, &block
+      _process(url, limit, limit, opts, &block)
     end
 
     def name
@@ -40,16 +39,16 @@ module Blinker
         resp.on_complete do |resp|
           if retry? resp
             if limit > 1
-              puts "Loading #{url} via manticore (attempt #{max - limit + 2} of #{max})" if @config.verbose
+              @logger.info("Loading #{url} via manticore (attempt #{max - limit + 2} of #{max})") if @config.verbose
               _process(url, limit - 1, max, &Proc.new)
             else
-              puts "Loading #{url} via manticore failed" if @config.verbose
+              @logger.info("Loading #{url} via manticore failed".red) if @config.verbose
               response = @client.respond_with(:code => 0, :status_message => "Server timed out after #{max} retries",
                                               :body => '').get(url)
-              block.call response, nil, nil
+              block.call(response, nil, nil)
             end
           else
-            block.call resp, nil, nil
+            block.call(resp, nil, nil)
           end
           @count += 1
         end

--- a/lib/blinkr/phantomjs_wrapper.rb
+++ b/lib/blinkr/phantomjs_wrapper.rb
@@ -7,28 +7,29 @@ require 'parallel'
 require 'open3'
 
 module Blinkr
-  class PhantomJSWrapper 
+  class PhantomJSWrapper
     include HttpUtils
 
     SNAP_JS = File.expand_path('snap.js', File.dirname(__FILE__))
 
     attr_reader :count
 
-    def initialize config, context
+    def initialize(config, context)
       @config = config.validate
       @context = context
       @count = 0
       @cache = Blinkr::Cache.new
+      @logger = Blinkr.logger
     end
 
-    def process_all urls, limit, opts = {}, &block
-      Parallel.each(urls, :in_threads => (@config.phantomjs_threads || Parallel.processor_count * 2)) do |url|
-        process url, limit, opts, &block
+    def process_all(urls, limit, opts = {}, &block)
+      Parallel.each(urls, in_threads: (@config.phantomjs_threads || Parallel.processor_count * 2)) do |url|
+        process(url, limit, opts, &block)
       end
     end
 
-    def process url, limit, opts = {}, &block
-      _process url, limit, limit, opts, &block
+    def process(url, limit, opts = {}, &block)
+      _process(url, limit, limit, opts, &block)
     end
 
     def name
@@ -36,50 +37,47 @@ module Blinkr
     end
 
     def command
-      'phantomjs'
+      @config.ignore_ssl ? 'phantomjs --ignore-ssl-errors=yes --ssl-protocol=any' : 'phantomjs'
     end
 
     private
 
-    def _process url, limit, max, opts = {}, &block
+    def _process(url, limit, max, opts = {}, &block)
       raise "limit must be set. url: #{url}, limit: #{limit}, max: #{max}" if limit.nil?
       unless @config.skipped? url
-        #Tempfile.open('blinkr') do|f|
         # Try and sidestep any unnecessary requests by checking the cache
         request = Typhoeus::Request.new(url)
         if @cache.get(request)
-          return block.call response, @cache.get("#{url}-resourceErrors"), @cache.get("#{url}-javascriptErrors")
+          return block.call(response, @cache.get("#{url}-resourceErrors"), @cache.get("#{url}-javascriptErrors"))
         end
 
         output, status = Open3.capture2("#{command} #{SNAP_JS} #{url} #{@config.viewport}")
         if status == 0
-          json = JSON.load(output)
-          response = Typhoeus::Response.new(:code => 200, :body => json['content'], :effective_url => json['url'],
-                                            :mock => true)
+          json = JSON.parse(output)
+          response = Typhoeus::Response.new(code: 200, body: json['content'], effective_url: json['url'],
+                                            mock: true)
           response.request = Typhoeus::Request.new(url)
           Typhoeus.stub(url).and_return(response)
           @cache.set(response.request, response)
           @cache.set("#{url}-resourceErrors", json['resourceErrors'])
           @cache.set("#{url}-javascriptErrors", json['javascriptErrors'])
-          block.call response, json['resourceErrors'], json['javascriptErrors']
+          block.call(response, json['resourceErrors'], json['javascriptErrors'])
         else
           if limit > 1
-            puts "Loading #{url} via phantomjs (attempt #{max - limit + 2} of #{max})" if @config.verbose
+            @logger.info("Loading #{url} via phantomjs (attempt #{max - limit + 2} of #{max})".yellow) if @config.verbose
             _process url, limit - 1, max, &block
           else
-            puts "Loading #{url} via phantomjs failed" if @config.verbose
+            @logger.info("Loading #{url} via phantomjs failed".red) if @config.verbose
             response = Typhoeus::Response.new(:code => 0, :status_message => "Server timed out after #{max} retries",
                                               :mock => true)
             response.request = Typhoeus::Request.new(url)
             Typhoeus.stub(url).and_return(response)
             @cache.set(response.request, response)
-            block.call response, nil, nil
+            block.call(response, nil, nil)
           end
-          end
-        #end
+        end
         @count += 1
       end
     end
-
   end
 end

--- a/lib/blinkr/report.html.slim
+++ b/lib/blinkr/report.html.slim
@@ -2,8 +2,8 @@ doctype html
 html[ng-app="blinkr"]
   head
     meta[http-equiv="Content-Type" content="text/html; charset=UTF-8"]
-    link[href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet"]
-    link[href="http://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet"]
+    link[href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet"]
+    link[href="https://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet"]
     script[src="https://code.jquery.com/jquery-2.1.4.js"]
     script[src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.js"]
     script[src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.5/angular.js"]
@@ -114,7 +114,7 @@ html[ng-app="blinkr"]
                     | {{page_error.code}} {{page_error.message}}
                   div
                     ' {{page_error.title}}
-                    a[href="{{page_error.title}}" target="_blank" ng-if="page_error.title.startsWith('http')"]
+                    a[href="{{page_error.title}}" target="_blank" ng-if="page_error.title.startsWith('https')"]
                       i.fa.fa-external-link
                   pre
                     | {{page_error.snippet}}

--- a/lib/blinkr/report.rb
+++ b/lib/blinkr/report.rb
@@ -1,20 +1,20 @@
 require 'slim'
 require 'ostruct'
 require 'blinkr/error'
+require 'fileutils'
 
 module Blinkr
   class Report
-
+    require 'colorize'
     TMPL = File.expand_path('report.html.slim', File.dirname(__FILE__))
 
-    def self.render(context, engine, config)
-      
-    end
+    def self.render(context, engine, config) end
 
-    def initialize context, engine, config
+    def initialize(context, engine, config)
       @context = context
       @engine = engine
       @config = config
+      @logger = Blinkr.logger
     end
 
     def render
@@ -29,17 +29,17 @@ module Blinkr
         page.categories = []
         page.types = []
         page.errors.each do |error|
-          raise "#{error.severity} not a valid severity. Must be one of #{::Blinkr::SEVERITY.join(',')}" unless ::Blinkr::SEVERITY.include? error.severity
-          raise "#{error.category} must be specified." if error.category.nil?
+          raise("#{error.severity} not a valid severity. Must be one of #{::Blinkr::SEVERITY.join(',')}") unless ::Blinkr::SEVERITY.include? error.severity
+          raise("#{error.category} must be specified.") if error.category.nil?
           @context.total += 1
-          @context.severity[error.severity] ||= OpenStruct.new({:count => 0})
+          @context.severity[error.severity] ||= OpenStruct.new(count: 0)
           @context.severity[error.severity].count += 1
           page.severities << error.severity
           page.max_severity = error.severity if ::Blinkr::SEVERITY.index(error.severity) > ::Blinkr::SEVERITY.index(page.max_severity)
-          @context.category[error.category] ||= OpenStruct.new({:count => 0})
+          @context.category[error.category] ||= OpenStruct.new(count: 0)
           @context.category[error.category].count += 1
           page.categories << error.category
-          @context.type[error.type] ||= OpenStruct.new({:count => 0})
+          @context.type[error.type] ||= OpenStruct.new(count: 0)
           @context.type[error.type].count += 1
           page.types << error.type
         end
@@ -49,12 +49,19 @@ module Blinkr
       end
       @context.pages = @context.pages.values
       File.open(@config.report, 'w') do |file|
-        file.write(Slim::Template.new(TMPL).render(OpenStruct.new({:blinkr => @context, :engine => @engine,
-                                                                   :errors => @context.to_json})))
+        file.write(Slim::Template.new(TMPL).render(OpenStruct.new(blinkr: @context, engine: @engine, errors: @context.to_json)))
       end
-      
-      puts "Wrote report to #{@config.report}" if @config.verbose
+      if @context.total > 0
+        @context.severity[:danger].nil? ? danger = 0 : danger = @context.severity[:danger].count
+        @context.severity[:warning].nil? ? warning = 0 : warning = @context.severity[:warning].count
+        puts("Completed with a total of " + "#{danger} errors".red + " and " + "#{warning} warnings".yellow)
+        File.open('blinkr_errors.json', 'w') do |file|
+          file.write(@context.to_json)
+        end
+      else
+        puts('Completed with no errors or warnings'.green)
+      end
+      puts("Wrote report to #{@config.report}") if @config.verbose
     end
-
   end
 end

--- a/lib/blinkr/sitemap.rb
+++ b/lib/blinkr/sitemap.rb
@@ -1,21 +1,39 @@
 require 'open-uri'
+require 'openssl'
 module Blinkr
-  module Sitemap
+  class Sitemap
+
+    def initialize(config)
+      @config = config
+    end
 
     def sitemap_locations
-      open_sitemap.css('loc').collect { |loc| loc.content }
+      open_sitemap.css('loc').collect(&:content)
     end
 
     private
 
     def open_sitemap
-      puts "Loading sitemap from #{@config.sitemap}"
-      if @config.sitemap =~ URI::regexp
-        Nokogiri::XML(open(@config.sitemap).read)
+      Blinkr.logger.info("Loading sitemap from #{@config.sitemap}".yellow)
+      if @config.sitemap =~ URI.regexp
+        Nokogiri::XML(handle_redirect(@config.sitemap).read)
       else
+        # locally stored sitemap.xml file
         Nokogiri::XML(File.open(@config.sitemap))
       end
     end
 
+    # Handle redirection forbidden error: http -> https
+    def handle_redirect(url)
+      uri = URI.parse(url)
+      tries = 3
+      begin
+        uri.open(redirect: false, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE)
+      rescue OpenURI::HTTPRedirect => redirect
+        uri = redirect.uri
+        retry if (tries -= 1) > 0
+        raise
+      end
+    end
   end
 end

--- a/lib/blinkr/snap.js
+++ b/lib/blinkr/snap.js
@@ -18,17 +18,18 @@ var last_request_timeout;
 var final_timeout;
 
 
-page.viewportSize = { width: info.view_port_width, height: 1500};
-page.settings = { loadImages: true, javascriptEnabled: true };
-
-// If you want to use additional phantomjs commands, place them here
-page.settings.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/28.0.1500.95 Safari/537.17';
+page.viewportSize = {width: info.view_port_width, height: 1500};
+page.settings = {
+    loadImages: true,
+    javascriptEnabled: true
+};
+page.settings.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36';
 
 // You can place custom headers here, example below.
 // page.customHeaders = {
 
 //      'X-Candy-OVERRIDE': 'https://api.live.bbc.co.uk/'
- 
+
 //  };
 
 // If you want to set a cookie, just add your details below in the following way.
@@ -44,57 +45,56 @@ page.settings.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleW
 //     'domain': '.bbc.co.uk'
 // });
 
-page.onResourceRequested = function(req) {
-  current_requests += 1;
+page.onResourceRequested = function (req) {
+    current_requests += 1;
 };
 
-page.onResourceReceived = function(resp) {
-  if (resp.stage === 'end') {
-    current_requests -= 1;
-  }
-  timeout();
+page.onResourceReceived = function (resp) {
+    if (resp.stage === 'end') {
+        current_requests -= 1;
+    }
+    timeout();
 };
 
-page.onResourceError = function(metadata) {
-  info.resourceErrors[info.resourceErrors.length] = metadata;
+page.onResourceError = function (metadata) {
+    info.resourceErrors[info.resourceErrors.length] = metadata;
 }
 
 
-page.onError = function(msg, trace) {
-  info.javascriptErrors[info.javascriptErrors.length] = {msg: msg, trace: trace};
+page.onError = function (msg, trace) {
+    info.javascriptErrors[info.javascriptErrors.length] = {msg: msg, trace: trace};
 }
 
-page.open(info.url, function(status) {
-  if (status !== 'success') {
-    exit(1);
-  }
+page.open(info.url, function (status) {
+    if (status !== 'success') {
+        exit(1);
+    }
 });
 
 var exit = function exit(err_code) {
-  info.content = page.content;
-  // Re-read the URL in case we've been redirected
-  info.url = page.url;
-  system.stdout.write(JSON.stringify(info));
-  if (err_code === undefined) {
-    err_code = 0;
-  }
-  phantom.exit(err_code);
+    info.content = page.content;
+    // Re-read the URL in case we've been redirected
+    info.url = page.url;
+    system.stdout.write(JSON.stringify(info));
+    if (err_code === undefined) {
+        err_code = 0;
+    }
+    phantom.exit(err_code);
 };
 
 function timeout() {
-  clearTimeout(last_request_timeout);
-  clearTimeout(final_timeout);
+    clearTimeout(last_request_timeout);
+    clearTimeout(final_timeout);
 
-  // If there's no more ongoing resource requests, wait for 1 second before
-  // exiting, just in case the page kicks off another request
-  if (current_requests < 1) {
-      clearTimeout(final_timeout);
-      last_request_timeout = setTimeout(exit, 1000);
-  }
+    // If there's no more ongoing resource requests, wait for 2 seconds before
+    // exiting, just in case the page kicks off another request
+    if (current_requests < 1) {
+        clearTimeout(final_timeout);
+        last_request_timeout = setTimeout(exit, 2000);
+    }
 
-  // Sometimes, straggling requests never make it back, in which
-  // case, timeout after 5 seconds and exit anyway
-  // TODO record which requests timed out!
-  final_timeout = setTimeout(exit, 5000);
+    // Sometimes, straggling requests never make it back, in which
+    // case, timeout after 5 seconds and exit anyway
+    // TODO record which requests timed out!
+    final_timeout = setTimeout(exit, 5000);
 }
-

--- a/lib/blinkr/typhoeus_wrapper.rb
+++ b/lib/blinkr/typhoeus_wrapper.rb
@@ -15,14 +15,15 @@ module Blinkr
       # Configure Typhoeus a bit
       Typhoeus::Config.verbose = true if config.vverbose
       Typhoeus::Config.cache = Blinkr::Cache.new
-      @hydra = Typhoeus::Hydra.new(:maxconnects => (@config.maxconnects || 30),
-                                   :max_total_connections => (@config.maxconnects || 30),
-                                   :pipelining => false,
-                                   :max_concurrency => (@config.maxconnects || 30))
+      @hydra = Typhoeus::Hydra.new(maxconnects: (@config.maxconnects || 30),
+                                   max_total_connections: (@config.maxconnects || 30),
+                                   pipelining: false,
+                                   max_concurrency: (@config.maxconnects || 30))
       Ethon.logger = Logger.new STDOUT if config.vverbose
       Ethon::Curl.set_option(:max_host_connections, 5, @hydra.multi.handle, :multi)
       @count = 0
       @context = context
+      @logger = Blinkr.logger
     end
 
     def process_all(urls, limit, opts = {}, &block)
@@ -33,35 +34,33 @@ module Blinkr
     end
 
     def process(url, limit, opts = {}, &block)
-      _process url, limit, limit, opts, &block
+      _process(url, limit, limit, opts, &block)
     end
 
     def debug(url)
       process(url, @config.max_retrys) do |resp|
-        puts "\n++++++++++"
-        puts "+ Blinkr +"
-        puts "++++++++++"
-        puts "\nRequest"
-        puts "======="
+        puts '++++++++++'
+        puts '\nRequest'
+        puts '======='
         puts "Method: #{resp.request.options[:method]}"
         puts "Max redirects: #{resp.request.options[:maxredirs]}"
         puts "Follow location header: #{resp.request.options[:followlocation]}"
         puts "Timeout (s): #{resp.request.options[:timeout] || 'none'}"
         puts "Connection timeout (s): #{resp.request.options[:connecttimeout] || 'none'}"
-        puts "\nHeaders"
-        puts "-------"
+        puts '\nHeaders'
+        puts '-------'
         unless resp.request.options[:headers].nil?
           resp.request.options[:headers].each do |name, value|
             puts "#{name}: #{value}"
           end
         end
-        puts "\nResponse"
-        puts "========"
+        puts '\nResponse'
+        puts '========'
         puts "Status Code: #{resp.code}"
         puts "Status Message: #{resp.status_message}"
         puts "Message: #{resp.return_message}" unless resp.return_message.nil? || resp.return_message == 'No error'
-        puts "\nHeaders"
-        puts "-------"
+        puts '\nHeaders'
+        puts '-------'
         puts resp.response_headers
       end
       @hydra.run
@@ -75,54 +74,51 @@ module Blinkr
 
     def _process(url, limit, max, opts = {}, &block)
       unless @config.skipped? url
-        req = Typhoeus::Request.new(
-            url,
-            opts.merge(:followlocation => true, :timeout => 60,
-                       :cookiefile => '_tmp/cookies', :cookiejar => '_tmp/cookies',
-                       :connecttimeout => 30, :maxredirs => 3)
-        )
+        req = Typhoeus::Request.new(url,
+                                    opts.merge(followlocation: true, timeout: 60,
+                                               cookiefile: '_tmp/cookies', cookiejar: '_tmp/cookies',
+                                               connecttimeout: 30, maxredirs: 3, ssl_verifypeer: false)
+                                   )
         req.on_complete do |resp|
           if retry? resp
             if resp.code.to_i == 0
-              puts "Response code of '0', using net/http for #{url}" if @config.verbose
+              @logger.info("Response code of '0', using net/http for #{url}") if @config.verbose
               response = nil
 
               begin
-                uri = URI::parse url
+                uri = URI.parse(url)
                 http_response = Net::HTTP.get_response(uri)
-                response = Typhoeus::Response.new(:code => http_response.code, :status_message => http_response.message,
-                                                  :mock => true)
+                response = Typhoeus::Response.new(code: http_response.code, status_message: http_response.message,
+                                                  mock: true)
               rescue
-                response = Typhoeus::Response.new(:code => 410, :status_message => 'Could not reach the resource',
-                                                  :mock => true)
+                response = Typhoeus::Response.new(code: 410, status_message: 'Could not reach the resource',
+                                                  mock: true)
               end
 
-              response.request = Typhoeus::Request.new(url)
+              response.request = Typhoeus::Request.new(url, ssl_verifypeer: false)
               Typhoeus.stub(url).and_return(response)
-              block.call response, nil, nil
+              block.call(response, nil, nil)
               next
             end
 
             if limit > 1
-              puts "Loading #{url} via typhoeus (attempt #{max - limit + 2} of #{max})" if @config.verbose
+              @logger.info("Loading #{url} via typhoeus (attempt #{max - limit + 2} of #{max})".yellow) if @config.verbose
               _process(url, limit - 1, max, &Proc.new)
             else
-              puts "Loading #{url} via typhoeus failed" if @config.verbose
-              response = Typhoeus::Response.new(:code => 0, :status_message => "Server timed out after #{max} retries",
-                                                :mock => true)
-              response.request = Typhoeus::Request.new(url)
+              @logger.info("Loading #{url} via typhoeus failed".red) if @config.verbose
+              response = Typhoeus::Response.new(code: 0, status_message: "Server timed out after #{max} retries",
+                                                mock: true)
+              response.request = Typhoeus::Request.new(url, ssl_verifypeer: false)
               Typhoeus.stub(url).and_return(response)
-              block.call response, nil, nil
+              block.call(response, nil, nil)
             end
           else
-            block.call resp, nil, nil
+            block.call(resp, nil, nil)
           end
         end
         @hydra.queue req
         @count += 1
       end
     end
-
   end
 end
-

--- a/lib/blinkr/version.rb
+++ b/lib/blinkr/version.rb
@@ -1,3 +1,3 @@
 module Blinkr
-  VERSION = '0.3.9'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/lib/blinkr/version.rb
+++ b/lib/blinkr/version.rb
@@ -1,4 +1,3 @@
 module Blinkr
-  VERSION='0.3.9'
+  VERSION = '0.3.9'.freeze
 end
-

--- a/test/test-site/blinkr.htm
+++ b/test/test-site/blinkr.htm
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <base href="http://www.example.com" target="_blank">
+    <title>Blinkr Home</title>
+    <script type="text/javascript">
+        function removeElement(node) {
+            node.parentNode.removeChild(node);
+        }
+
+        function load() {
+            slow_link = document.createElement("a");
+            some_text = document.createTextNode("Internal slow link");
+            slow_link.setAttribute('href', 'http://www.example.com/internal-link-6');
+            slow_link.setAttribute('class', 'slow');
+            slow_link.appendChild(some_text);
+            dumping_ground = document.getElementById('dumping_ground');
+            //wait for 0.5 second and then add the links
+            var t1 = setTimeout("dumping_ground.appendChild(slow_link);", 500);
+            var t2 = setTimeout("document.getElementById('will_become_visible').style.display='block';", 500);
+            var t3 = setTimeout("document.getElementById('will_become_invisible').style.display='none';", 500);
+        }
+        window.onload = load;
+    </script>
+</head>
+<body>
+<h1>Blinkr</h1>
+<span class='welcome'>A broken page and link checker for websites. Optionally uses phantomjs to render pages to check resource loading, links created by JS, and report any JS page load errors.</span>
+<table>
+    <tr>
+        <td><a href='http://www.example.com/internal-link-1'>Link One</a></td>
+        <td><a href='http://www.example.com/internal-link-2'>Link Two</a></td>
+        <td><a href='http://www.example.com/internal-link-3'>Link Three</a></td>
+        <td><a href='http://www.example.com/internal-link-4'>Link Four</a></td>
+        <td><a href='http://www.example.com/internal-link-5'>Link Five</a></td>
+    </tr>
+</table>
+
+<table>
+    <tr>
+        <td><a href="http://www.externalhost.com/external-link-1">External Link One</a></td>
+        <td><a href="http://www.externalhost.com/external-link-2">External Link Two</a></td>
+        <td><a href="http://www.externalhost.com/external-link-3">External Link Three</a></td>
+        <td><a href="http://www.externalhost.com/external-link-4">External Link Four</a></td>
+        <td><a href="http://www.externalhost.com/external-link-5">External Link Five</a></td>
+    </tr>
+</table>
+
+<div id='container_with_element'>
+    <div class='embedded_element'>
+    </div>
+</div>
+
+<p id='dumping_ground'>
+
+</p>
+
+</body>
+</html>

--- a/test/unit-test/blinkr_test.rb
+++ b/test/unit-test/blinkr_test.rb
@@ -1,0 +1,54 @@
+require_relative '../../test/unit-test/test_helper'
+require 'minitest/autorun'
+require 'mocha/mini_test'
+
+class TestBlinkr < Minitest::Test
+
+  describe Blinkr do
+
+    it 'should load user specified config file in a hash' do
+      options = {}
+      options[:config_file] = "#{__dir__}/config/valid_blinkr.yaml"
+
+      config = mock
+      blinkr_engine = mock
+
+      Blinkr::Config.expects(:read).with(options[:config_file], options.tap { |hs| hs.delete(options[:config_file]) }).returns(config)
+      Blinkr::Engine.expects(:new).with(config).returns(blinkr_engine)
+
+      blinkr_engine.expects(:run)
+      Blinkr.run(options)
+    end
+
+    it 'should load default config if not specified' do
+
+      options = {}
+
+      config = mock
+      blinkr_engine = mock
+
+      Blinkr::Config.expects(:new).with(options).returns(config)
+      Blinkr::Engine.expects(:new).with(config).returns(blinkr_engine)
+
+      blinkr_engine.expects(:run)
+
+      Blinkr.run(options)
+    end
+
+    it 'can check a single_url' do
+      options = {}
+      options[:single_url] = 'http://www.example.com/foo'
+
+      config = mock
+      typehouse_wrapper = mock
+
+      Blinkr::Config.expects(:new).with(options).returns(config)
+
+      Blinkr::TyphoeusWrapper.expects(:new).with(config, is_a(OpenStruct)).returns(typehouse_wrapper)
+
+      typehouse_wrapper.expects(:debug)
+
+      Blinkr.run(options)
+    end
+  end
+end

--- a/test/unit-test/config/invalid_ignores.yaml
+++ b/test/unit-test/config/invalid_ignores.yaml
@@ -1,0 +1,2 @@
+ignores:
+  - http://www.acme.com/foo

--- a/test/unit-test/config/sitemap.xml
+++ b/test/unit-test/config/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>http://www.example.com/home</loc>
+    <lastmod>2017-06-14T11:21:47+01:00</lastmod>
+  </url>
+</urlset>

--- a/test/unit-test/config/valid_blinkr.yaml
+++ b/test/unit-test/config/valid_blinkr.yaml
@@ -1,0 +1,10 @@
+# The URL to check (often specificed on the command line)
+base_url: http://www.example.com/
+browser: phantomjs
+phantomjs_threads: 20
+report: blinkr.html
+max_retrys: 3
+max_page_retrys: 3
+ignore_fragments: true
+skips:
+  - !ruby/regexp /^http:\/\/(www\.)?example\.com\/foo/

--- a/test/unit-test/config/valid_regex_ignores.yaml
+++ b/test/unit-test/config/valid_regex_ignores.yaml
@@ -1,0 +1,8 @@
+ignores:
+  - url: http://www.example.com/foo
+    message: Not Found
+  - url: !ruby/regexp /^http:\/\/(www\.)?example\.com\/foo/
+    code: 500
+
+skips:
+  - !ruby/regexp /^http:\/\/(www\.)?example\.com\/bar/

--- a/test/unit-test/config/valid_skips.yaml
+++ b/test/unit-test/config/valid_skips.yaml
@@ -1,0 +1,3 @@
+skips:
+  - !ruby/regexp /^http:\/\/(www\.)?example\.com\/regex$/
+  - http://www.example.com/bar

--- a/test/unit-test/config/valid_string_ignores.yaml
+++ b/test/unit-test/config/valid_string_ignores.yaml
@@ -1,0 +1,5 @@
+ignores:
+  - url: http://www.example.com/foo
+    message: Not Found
+    code: 404
+    snippet: <a href='/foo/'>I'm a link</a>

--- a/test/unit-test/config_test.rb
+++ b/test/unit-test/config_test.rb
@@ -1,0 +1,247 @@
+require_relative '../../test/unit-test/test_helper'
+require 'minitest/autorun'
+require 'mocha/mini_test'
+
+class TestBlinkr < Minitest::Test
+
+  describe Blinkr::Config do
+
+    it 'should raise an error if it cannot read config file' do
+      options = {}
+      args = {}
+      options[:config_file] = '/no/way/this/exists.yaml'
+      exception = assert_raises(RuntimeError) {
+        Blinkr::Config.read(options[:config_file], args)
+      }
+      assert_equal("Cannot read #{options[:config_file]}", exception.message)
+    end
+
+    it 'should create a default hash when no config is specified' do
+      options = {}
+      expected_default_hash = { skips: [], ignores: [], environments: [], max_retrys: 3,
+                               browser: 'phantomjs', viewport: 1200, phantomjs_threads: 10,
+                               report: 'blinkr.html', warning_on_300s: false,
+                               ignore_internal: false, ignore_external: false,
+                               warn_js_errors: false, warn_inline_css: false,
+                               ignore_ssl: false, warn_resource_errors: false }.freeze
+
+      actual_hash = Blinkr::Config.new(options)
+      assert_equal(expected_default_hash, actual_hash.to_h)
+    end
+
+    it 'should create a merged Hash of user specified config options and default config options' do
+      options = {}
+      args = {}
+      options[:config_file] = "#{__dir__}/config/valid_blinkr.yaml"
+      actual_hash = Blinkr::Config.read(options[:config_file], args)
+      expected_hash = { skips: [/^http:\/\/(www\.)?example\.com\/foo/], ignores: [], environments: [], max_retrys: 3, browser: 'phantomjs', viewport: 1200, phantomjs_threads:20, report: 'blinkr.html', warning_on_300s: false, ignore_internal: false, ignore_external: false, warn_js_errors: false, warn_inline_css: false, ignore_ssl: false, warn_resource_errors: false, base_url: 'http://www.example.com/', max_page_retrys: 3, ignore_fragments: true, config_file:"#{__dir__}/config/valid_blinkr.yaml" }
+      assert_equal expected_hash.to_s, actual_hash.to_h.to_s
+    end
+
+    it 'validate raises an error when ignores does not contain a Hash' do
+      options = {}
+      args = {}
+      options[:config_file] = "#{__dir__}/config/invalid_ignores.yaml"
+      exception = assert_raises(RuntimeError) {
+        Blinkr::Config.read(options[:config_file], args).validate
+      }
+      assert_equal('An ignore must be a hash', exception.message)
+    end
+
+    it 'validate raises an error when base_url is not specified' do
+      options = {}
+      exception = assert_raises(RuntimeError) {
+        Blinkr::Config.new(options).validate
+      }
+      assert_equal('Must specify base_url', exception.message)
+    end
+
+    it 'validate raises an error when sitemap is not specified' do
+      options = {}
+      options[:base_url] = 'http://www.example.com'
+      exception = assert_raises(RuntimeError) {
+        config = Blinkr::Config.new(options)
+        config.stubs(:sitemap).with(nil)
+        config.validate
+      }
+      assert_equal('Must specify sitemap', exception.message)
+    end
+
+    it 'sitemap appends base_url with /sitemap.xml if not specified' do
+      options = {}
+      options[:base_url] = 'http://www.example.com'
+      assert_equal(Blinkr::Config.new(options).sitemap, "#{options[:base_url]}/sitemap.xml")
+    end
+
+    it 'accepts user specified sitemap' do
+      options = {}
+      options[:sitemap] = 'http://www.foo.com/sitemap.xml'
+      options[:base_url] = 'http://www.example.com'
+      assert_equal(Blinkr::Config.new(options).sitemap, "#{options[:sitemap]}")
+    end
+
+    it 'accepts sitemap as local xml filetype' do
+      options = {}
+      options[:sitemap] = "#{__dir__}/config/sitemap.xml"
+      options[:base_url] = 'http://www.example.com'
+      assert_equal(Blinkr::Config.new(options).sitemap, "#{options[:sitemap]}")
+    end
+
+    it 'max_page_retrys raises an error if nil' do
+      options = {}
+      options[:base_url] = 'http://www.example.com'
+      options[:max_retrys] = nil
+      exception = assert_raises(RuntimeError) {
+        config = Blinkr::Config.new(options)
+        config.max_page_retrys
+      }
+      assert_equal('Retrys is nil', exception.message)
+    end
+
+    it 'ignores containing url option can be specified in Regex' do
+      error = Blinkr::Error.new(severity: 'danger',
+                                category: 'Broken link',
+                                type: '<a href=""> target cannot be loaded',
+                                url: 'http://www.example.com/foo', title: 'Foobar',
+                                code: 500, message: 'Foobar',
+                                detail: 'detail', snippet: '',
+                                icon: 'fa-bookmark-o')
+      options = {}
+      args = {}
+      options[:config_file] = "#{__dir__}/config/valid_regex_ignores.yaml"
+      ignores = Blinkr::Config.read(options[:config_file], args).ignored?(error)
+      assert_equal(ignores, true)
+    end
+
+    it 'ignores containing url can be specified as a string' do
+      error = Blinkr::Error.new(severity: 'danger',
+                                type: '<a href=""> target cannot be loaded',
+                                url: 'http://www.example.com/foo', title: 'Foobar',
+                                code: 500, message: 'Foobar',
+                                detail: 'detail', snippet: '',
+                                icon: 'fa-bookmark-o')
+      options = {}
+      args = {}
+      options[:config_file] = "#{__dir__}/config/valid_string_ignores.yaml"
+      ignores = Blinkr::Config.read(options[:config_file], args).ignored?(error)
+      assert_equal(ignores, true)
+    end
+
+    it 'ignores option returns boolean (false) when no matched urls are found' do
+      error = Blinkr::Error.new(severity: 'danger',
+                                type: '<a href=""> target cannot be loaded',
+                                url: 'http://www.foo.com/bar', title: 'Foobar',
+                                code: 500, message: 'Foobar',
+                                detail: 'detail', snippet: "<a href='/foo/'>Oh Hi</a>",
+                                icon: 'fa-bookmark-o')
+      options = {}
+      args = {}
+      options[:config_file] = "#{__dir__}/config/valid_string_ignores.yaml"
+      ignores = Blinkr::Config.read(options[:config_file], args).ignored?(error)
+      assert_equal(ignores, false)
+    end
+
+    it 'ignores option ignore user specified error codes' do
+      error = Blinkr::Error.new(severity: 'danger',
+                                type: '<a href=""> target cannot be loaded',
+                                url: 'http://www.foo.com/bar', title: 'Foobar',
+                                code: 404, message: 'Foobar',
+                                detail: 'detail', snippet: '',
+                                icon: 'fa-bookmark-o')
+      options = {}
+      args = {}
+      options[:config_file] = "#{__dir__}/config/valid_string_ignores.yaml"
+      ignores = Blinkr::Config.read(options[:config_file], args).ignored?(error)
+      assert_equal(ignores, true)
+    end
+
+    it 'returns false when no matched error codes are found' do
+      error = Blinkr::Error.new(severity: 'danger',
+                                type: '<a href=""> target cannot be loaded',
+                                url: 'http://www.foo.com/bar', title: 'Foobar',
+                                code: 503, message: 'Foobar',
+                                detail: 'detail', snippet: '',
+                                icon: 'fa-bookmark-o')
+      options = {}
+      args = {}
+      options[:config_file] = "#{__dir__}/config/valid_string_ignores.yaml"
+      ignores = Blinkr::Config.read(options[:config_file], args).ignored?(error)
+      assert_equal(ignores, false)
+    end
+
+
+    it 'ignores option can ignore user specified messages ' do
+      error = Blinkr::Error.new(severity: 'danger',
+                                type: '<a href=""> target cannot be loaded',
+                                url: 'http://www.foo.com/bar', title: 'Foobar',
+                                code: 500, message: 'Not Found',
+                                detail: 'detail', snippet: '',
+                                icon: 'fa-bookmark-o')
+      options = {}
+      args = {}
+      options[:config_file] = "#{__dir__}/config/valid_string_ignores.yaml"
+      ignores = Blinkr::Config.read(options[:config_file], args).ignored?(error)
+      assert_equal(ignores, true)
+    end
+
+    it 'returns false when no matched messages are found' do
+      error = Blinkr::Error.new(severity: 'danger',
+                                type: '<a href=""> target cannot be loaded',
+                                url: 'http://www.foo.com/bar', title: 'Foobar',
+                                code: 503, message: 'Foobar',
+                                detail: 'detail', snippet: '',
+                                icon: 'fa-bookmark-o')
+      options = {}
+      args = {}
+      options[:config_file] = "#{__dir__}/config/valid_string_ignores.yaml"
+      ignores = Blinkr::Config.read(options[:config_file], args).ignored?(error)
+      assert_equal(ignores, false)
+    end
+
+
+    it 'ignores option can ignore user specified snippet' do
+      error = Blinkr::Error.new(severity: 'danger',
+                                type: '<a href=""> target cannot be loaded',
+                                url: 'http://www.foo.com/bar', title: 'Foobar',
+                                code: 500, message: 'Foobar',
+                                detail: 'detail', snippet: "<a href='/foo/'>I'm a link</a>",
+                                icon: 'fa-bookmark-o')
+      options = {}
+      args = {}
+      options[:config_file] = "#{__dir__}/config/valid_string_ignores.yaml"
+      ignores = Blinkr::Config.read(options[:config_file], args).ignored?(error)
+      assert_equal(ignores, true)
+    end
+
+    it 'returns false when no matched ignored snippets are found' do
+      error = Blinkr::Error.new(severity: 'danger',
+                                type: '<a href=""> target cannot be loaded',
+                                url: 'http://www.foo.com/bar', title: 'Foobar',
+                                code: 503, message: 'Foobar',
+                                detail: 'detail', snippet: "<a href='/foo/'>Oh Hi</a>",
+                                icon: 'fa-bookmark-o')
+      options = {}
+      args = {}
+      options[:config_file] = "#{__dir__}/config/valid_string_ignores.yaml"
+      ignores = Blinkr::Config.read(options[:config_file], args).ignored?(error)
+      assert_equal(ignores, false)
+    end
+
+    it 'skips option must ignore user configured links/pages specified in String' do
+      options = {}
+      args = {}
+      options[:config_file] = "#{__dir__}/config/valid_skips.yaml"
+      skips = Blinkr::Config.read(options[:config_file], args).skipped?('http://www.example.com/bar')
+      assert_equal(true, skips)
+    end
+
+    it 'skips option must ignore user configured links/pages specified in Regex' do
+      options = {}
+      args = {}
+      options[:config_file] = "#{__dir__}/config/valid_skips.yaml"
+      skips = Blinkr::Config.read(options[:config_file], args).skipped?('http://www.example.com/regex')
+      assert_equal(true, skips)
+    end
+
+  end
+end

--- a/test/unit-test/engine_test.rb
+++ b/test/unit-test/engine_test.rb
@@ -1,0 +1,11 @@
+require_relative '../../test/unit-test/test_helper'
+require 'minitest/autorun'
+require 'mocha/mini_test'
+
+class TestBlinkr < Minitest::Test
+
+  describe Blinkr::Engine do
+
+  end
+end
+

--- a/test/unit-test/extensions/links_test.rb
+++ b/test/unit-test/extensions/links_test.rb
@@ -1,0 +1,32 @@
+require_relative '../test_helper'
+require 'minitest/autorun'
+require 'mocha/mini_test'
+require 'blinkr/sitemap'
+require 'blinkr/error'
+require 'blinkr/typhoeus_wrapper'
+
+class TestBlinkr < Minitest::Test
+
+  describe Blinkr::Extensions::Links do
+
+    it 'collects links from page content' do
+      options = {}
+      options[:base_url] = 'http://www.example.com'
+      @config = Blinkr::Config.new(options)
+
+      test_site = Nokogiri::HTML(File.read("#{File.expand_path(".")}/test/test-site/blinkr.htm"))
+      response = Typhoeus::Response.new(code: 200, body: test_site, effective_url: options[:base_url])
+      foo = Typhoeus.stub(options[:base_url]).and_return(response)
+
+      links = Blinkr::Extensions::Links.new(@config)
+      page = OpenStruct.new(response: foo[0],
+                            body: foo[0].body.freeze,
+                            errors: nil,
+                            resource_errors: [],
+                            javascript_errors: [])
+
+      assert_equal(10, links.collect(page).size)
+    end
+
+  end
+end

--- a/test/unit-test/sitemap_test.rb
+++ b/test/unit-test/sitemap_test.rb
@@ -1,0 +1,45 @@
+require_relative '../../test/unit-test/test_helper'
+require 'minitest/autorun'
+require 'mocha/mini_test'
+require 'blinkr/sitemap'
+
+class TestBlinkr < Minitest::Test
+
+  describe Blinkr::Sitemap do
+
+    before do
+      # make private method testable by switching it to public
+      # for the purposes of testing only.
+      Blinkr::Sitemap.send(:public, :open_sitemap)
+    end
+
+    it 'loads sitemap from locally stored sitemap' do
+      options = {}
+      options[:base_url] = 'http://www.example.com'
+      options[:sitemap] = "#{__dir__}/config/sitemap.xml"
+      @config = Blinkr::Config.new(options)
+      sitemap = Blinkr::Sitemap.new(@config).open_sitemap
+      assert_includes(sitemap.to_s, 'http://www.example.com/home')
+    end
+
+    it 'loads sitemap from URL' do
+      options = {}
+      options[:base_url] = 'http://www.example.com'
+      stub_request(:get, "#{options[:base_url]}/sitemap.xml").to_return(status: 200, body: sitemap_stub, :headers => {})
+      @config = Blinkr::Config.new(options)
+      sitemap = Blinkr::Sitemap.new(@config).open_sitemap
+
+      assert_includes(sitemap.to_s, 'test-site/blinkr.htm')
+    end
+
+    it 'returns sitemap locations' do
+      options = {}
+      options[:base_url] = 'http://www.example.com'
+      stub_request(:get, "#{options[:base_url]}/sitemap.xml").to_return(status: 200, body: sitemap_stub, :headers => {})
+      @config = Blinkr::Config.new(options)
+      sitemap = Blinkr::Sitemap.new(@config)
+      assert_equal(1, sitemap.sitemap_locations.size)
+    end
+
+  end
+end

--- a/test/unit-test/test_helper.rb
+++ b/test/unit-test/test_helper.rb
@@ -1,0 +1,17 @@
+require 'blinkr'
+require 'minitest/reporters'
+require 'webmock/minitest'
+reporter_options = {color: true}
+Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(reporter_options)]
+
+
+def sitemap_stub
+  "<?xml version='1.0' encoding='UTF-8'?>
+   <urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'>
+   <url>
+   <loc>#{__dir__}/test-site/blinkr.htm</loc>
+   <lastmod>2017-06-14T11:21:47+01:00</lastmod>
+   </url>
+   </urlset>"
+end
+


### PR DESCRIPTION
As part of the developers.redhat.com build pipeline we test internal and or external site urls. I decided to refactor Blinkr a while ago and have been running this branch on PR's for quite some time. @LightGuard can vouch for this.

The 0.4.0 release contains updated ruby syntax, bug fixes, unit-tests, and additional features. Additional features include:
- ignore internal urls
- ignore external urls
- Option to ignore ssl errors (when running against staging hosts that contain outdated certs)
- Warnings for js errors, inline css, and resource errors are now optional to reduce noise (defaults to false).

On my TODO list once I have this merged:
- Add more unit-tests
- Replace phantom with headless chrome. (or have it as an additional driver)