### PR TITLE
fix error in TyphoeusWrapper - undefined method 'to_i' for false:FalseClass (NoMethodError)

### DIFF
--- a/lib/blinkr/typhoeus_wrapper.rb
+++ b/lib/blinkr/typhoeus_wrapper.rb
@@ -17,7 +17,7 @@ module Blinkr
       Typhoeus::Config.cache = Blinkr::Cache.new
       @hydra = Typhoeus::Hydra.new(maxconnects: (@config.maxconnects || 30),
                                    max_total_connections: (@config.maxconnects || 30),
-                                   pipelining: false,
+                                   pipelining: 0,
                                    max_concurrency: (@config.maxconnects || 30))
       Ethon.logger = Logger.new STDOUT if config.vverbose
       Ethon::Curl.set_option(:max_host_connections, 5, @hydra.multi.handle, :multi)

--- a/test/unit-test/typhoeus_wrapper_test.rb
+++ b/test/unit-test/typhoeus_wrapper_test.rb
@@ -1,0 +1,17 @@
+require_relative '../../test/unit-test/test_helper'
+require 'minitest/autorun'
+require 'mocha/mini_test'
+
+class TestTyphoeusWrapper < Minitest::Test
+
+  describe Blinkr do
+
+    it 'should initialize without error' do
+      config = OpenStruct.new
+      context = OpenStruct.new
+      config.expects(:validate).returns(config)
+
+      Blinkr::TyphoeusWrapper.new(config, context)
+    end
+  end
+end

--- a/test/unit-test/typhoeus_wrapper_test.rb
+++ b/test/unit-test/typhoeus_wrapper_test.rb
@@ -4,7 +4,7 @@ require 'mocha/mini_test'
 
 class TestTyphoeusWrapper < Minitest::Test
 
-  describe Blinkr do
+  describe TestTyphoeusWrapper do
 
     it 'should initialize without error' do
       config = OpenStruct.new


### PR DESCRIPTION
### Error

```
➜ blinkr -u http://www.google.com
Started at 2019-11-11T20:30:38-05:00
Traceback (most recent call last):
  16: from /Users/me/.rbenv/versions/2.6.4/bin/blinkr:23:in `<main>'
  15: from /Users/me/.rbenv/versions/2.6.4/bin/blinkr:23:in `load'
  14: from /Users/me/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/blinkr-0.3.9/bin/blinkr:33:in `<top (required)>'
  13: from /Users/me/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/blinkr-0.3.9/lib/blinkr.rb:19:in `run'
  12: from /Users/me/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/blinkr-0.3.9/lib/blinkr/engine.rb:45:in `run'
  11: from /Users/me/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/blinkr-0.3.9/lib/blinkr/engine.rb:45:in `new'
  10: from /Users/me/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/blinkr-0.3.9/lib/blinkr/typhoeus_wrapper.rb:18:in `initialize'
   9: from /Users/me/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/blinkr-0.3.9/lib/blinkr/typhoeus_wrapper.rb:18:in `new'
   8: from /Users/me/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/typhoeus-0.8.0/lib/typhoeus/hydra.rb:92:in `initialize'
   7: from /Users/me/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/typhoeus-0.8.0/lib/typhoeus/hydra.rb:92:in `new'
   6: from /Users/me/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/ethon-0.12.0/lib/ethon/multi.rb:80:in `initialize'
   5: from /Users/me/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/ethon-0.12.0/lib/ethon/multi.rb:95:in `set_attributes'
   4: from /Users/me/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/ethon-0.12.0/lib/ethon/multi.rb:95:in `each_pair'
   3: from /Users/me/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/ethon-0.12.0/lib/ethon/multi.rb:99:in `block in set_attributes'
   2: from /Users/me/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/ethon-0.12.0/lib/ethon/multi.rb:99:in `call'
   1: from /Users/me/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/ethon-0.12.0/lib/ethon/multi/options.rb:41:in `pipelining='
/Users/me/.rbenv/versions/2.6.4/lib/ruby/gems/2.6.0/gems/ethon-0.12.0/lib/ethon/multi/options.rb:107:in `value_for': undefined method `to_i' for false:FalseClass (NoMethodError)
```

### Cause
The `pipelining` boolean in Typhoeus' dep Ethon must be specified using a `1` or `0` value.
https://github.com/typhoeus/ethon/blob/master/lib/ethon/multi.rb#L27